### PR TITLE
Resolve Potential Namespace Collisions

### DIFF
--- a/source/AsepriteDotNet.Tests/Common/ColorTests.cs
+++ b/source/AsepriteDotNet.Tests/Common/ColorTests.cs
@@ -21,6 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
+
 namespace AsepriteDotNet.Tests;
 
 public sealed class ColorTests

--- a/source/AsepriteDotNet.Tests/Common/PointTests.cs
+++ b/source/AsepriteDotNet.Tests/Common/PointTests.cs
@@ -21,6 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
+
 namespace AsepriteDotNet.Tests;
 
 public sealed class PointTests

--- a/source/AsepriteDotNet.Tests/Common/RectangleTests.cs
+++ b/source/AsepriteDotNet.Tests/Common/RectangleTests.cs
@@ -21,6 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
+
 namespace AsepriteDotNet.Tests;
 
 public sealed class RectangleTests

--- a/source/AsepriteDotNet.Tests/Common/SizeTests.cs
+++ b/source/AsepriteDotNet.Tests/Common/SizeTests.cs
@@ -21,6 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
+
 namespace AsepriteDotNet.Tests;
 
 public sealed class SizeTests

--- a/source/AsepriteDotNet.Tests/IO/AsepriteFileReaderTests.cs
+++ b/source/AsepriteDotNet.Tests/IO/AsepriteFileReaderTests.cs
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
 using AsepriteDotNet.Document;
 using AsepriteDotNet.IO;
 

--- a/source/AsepriteDotNet/AsepriteFile.cs
+++ b/source/AsepriteDotNet/AsepriteFile.cs
@@ -19,7 +19,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ----------------------------------------------------------------------------- */
 using System.Collections.ObjectModel;
-
+using AsepriteDotNet.Common;
 using AsepriteDotNet.Document;
 using AsepriteDotNet.Image;
 using AsepriteDotNet.IO;

--- a/source/AsepriteDotNet/Common/BlendMode.cs
+++ b/source/AsepriteDotNet/Common/BlendMode.cs
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
-namespace AsepriteDotNet;
+namespace AsepriteDotNet.Common;
 
 /// <summary>
 ///     Defines the blend mode used when blending two color values.

--- a/source/AsepriteDotNet/Common/Color.cs
+++ b/source/AsepriteDotNet/Common/Color.cs
@@ -20,7 +20,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ----------------------------------------------------------------------------- */
 using System.Diagnostics.CodeAnalysis;
 
-namespace AsepriteDotNet;
+namespace AsepriteDotNet.Common;
 
 /// <summary>
 ///     Represents an RGBA (red, green, blue, alpha) color value.

--- a/source/AsepriteDotNet/Common/ColorDepth.cs
+++ b/source/AsepriteDotNet/Common/ColorDepth.cs
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
-namespace AsepriteDotNet;
+namespace AsepriteDotNet.Common;
 
 /// <summary>
 ///     Defines the color depth mode used by an Aseprite image.

--- a/source/AsepriteDotNet/Common/LoopDirection.cs
+++ b/source/AsepriteDotNet/Common/LoopDirection.cs
@@ -18,7 +18,7 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ----------------------------------------------------------------------------- */
-namespace AsepriteDotNet;
+namespace AsepriteDotNet.Common;
 
 /// <summary>
 ///     Defines the values that describe an animation loop direction.

--- a/source/AsepriteDotNet/Common/Point.cs
+++ b/source/AsepriteDotNet/Common/Point.cs
@@ -20,7 +20,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ----------------------------------------------------------------------------- */
 using System.Diagnostics.CodeAnalysis;
 
-namespace AsepriteDotNet;
+namespace AsepriteDotNet.Common;
 
 /// <summary>
 ///     Represents an x- and y-coordinate point in a two dimensional plane.

--- a/source/AsepriteDotNet/Common/Rectangle.cs
+++ b/source/AsepriteDotNet/Common/Rectangle.cs
@@ -20,7 +20,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ----------------------------------------------------------------------------- */
 using System.Diagnostics.CodeAnalysis;
 
-namespace AsepriteDotNet;
+namespace AsepriteDotNet.Common;
 
 /// <summary>
 ///     Represents a rectangular area with with width, height, x-coordinate, and

--- a/source/AsepriteDotNet/Common/Size.cs
+++ b/source/AsepriteDotNet/Common/Size.cs
@@ -20,7 +20,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ----------------------------------------------------------------------------- */
 using System.Diagnostics.CodeAnalysis;
 
-namespace AsepriteDotNet;
+namespace AsepriteDotNet.Common;
 
 /// <summary>
 ///     Represents the width and height of something.

--- a/source/AsepriteDotNet/Document/Cel.cs
+++ b/source/AsepriteDotNet/Document/Cel.cs
@@ -21,6 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
+
 namespace AsepriteDotNet.Document;
 
 /// <summary>

--- a/source/AsepriteDotNet/Document/Frame.cs
+++ b/source/AsepriteDotNet/Document/Frame.cs
@@ -20,8 +20,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ----------------------------------------------------------------------------- */
 using System.Collections;
 using System.Collections.ObjectModel;
-
 using AsepriteDotNet.IO.Image;
+using AsepriteDotNet.Common;
 
 namespace AsepriteDotNet.Document;
 
@@ -126,7 +126,7 @@ public sealed class Frame : IEnumerable<Cel>
             }
             else
             {
-                
+
                 continue;
             }
 

--- a/source/AsepriteDotNet/Document/GroupLayer.cs
+++ b/source/AsepriteDotNet/Document/GroupLayer.cs
@@ -24,6 +24,7 @@ SOFTWARE.
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using AsepriteDotNet.Common;
 
 namespace AsepriteDotNet.Document;
 

--- a/source/AsepriteDotNet/Document/ImageCel.cs
+++ b/source/AsepriteDotNet/Document/ImageCel.cs
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
 using AsepriteDotNet.IO.Image;
 
 namespace AsepriteDotNet.Document;

--- a/source/AsepriteDotNet/Document/ImageLayer.cs
+++ b/source/AsepriteDotNet/Document/ImageLayer.cs
@@ -21,6 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
+
 namespace AsepriteDotNet.Document;
 
 /// <summary>

--- a/source/AsepriteDotNet/Document/Layer.cs
+++ b/source/AsepriteDotNet/Document/Layer.cs
@@ -21,6 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
+
 namespace AsepriteDotNet.Document;
 
 /// <summary>

--- a/source/AsepriteDotNet/Document/LinkedCel.cs
+++ b/source/AsepriteDotNet/Document/LinkedCel.cs
@@ -21,6 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
+
 namespace AsepriteDotNet.Document;
 
 /// <summary>

--- a/source/AsepriteDotNet/Document/Palette.cs
+++ b/source/AsepriteDotNet/Document/Palette.cs
@@ -21,6 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
+
 using System.Collections;
 
 namespace AsepriteDotNet.Document;

--- a/source/AsepriteDotNet/Document/SliceKey.cs
+++ b/source/AsepriteDotNet/Document/SliceKey.cs
@@ -21,6 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
+
 namespace AsepriteDotNet.Document;
 
 /// <summary>

--- a/source/AsepriteDotNet/Document/Tag.cs
+++ b/source/AsepriteDotNet/Document/Tag.cs
@@ -18,6 +18,8 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ----------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
+
 namespace AsepriteDotNet.Document;
 
 /// <summary>

--- a/source/AsepriteDotNet/Document/TilemapCel.cs
+++ b/source/AsepriteDotNet/Document/TilemapCel.cs
@@ -21,6 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
+
 namespace AsepriteDotNet.Document;
 
 /// <summary>

--- a/source/AsepriteDotNet/Document/TilemapLayer.cs
+++ b/source/AsepriteDotNet/Document/TilemapLayer.cs
@@ -21,6 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
+
 namespace AsepriteDotNet.Document;
 
 /// <summary>

--- a/source/AsepriteDotNet/Document/Tileset.cs
+++ b/source/AsepriteDotNet/Document/Tileset.cs
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
 using AsepriteDotNet.Image;
 using AsepriteDotNet.IO.Image;
 

--- a/source/AsepriteDotNet/Document/UserData.cs
+++ b/source/AsepriteDotNet/Document/UserData.cs
@@ -19,7 +19,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ----------------------------------------------------------------------------- */
 using System.Diagnostics.CodeAnalysis;
-
+using AsepriteDotNet.Common;
 namespace AsepriteDotNet.Document;
 
 /// <summary>

--- a/source/AsepriteDotNet/IO/AsepriteFileReader.cs
+++ b/source/AsepriteDotNet/IO/AsepriteFileReader.cs
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
 using System.Diagnostics;
-
+using AsepriteDotNet.Common;
 using AsepriteDotNet.Compression;
 using AsepriteDotNet.Document;
 

--- a/source/AsepriteDotNet/IO/Image/PngWriter.cs
+++ b/source/AsepriteDotNet/IO/Image/PngWriter.cs
@@ -24,7 +24,7 @@ SOFTWARE.
 using System.Buffers.Binary;
 using System.IO.Compression;
 using System.Text;
-
+using AsepriteDotNet.Common;
 using AsepriteDotNet.Compression;
 
 namespace AsepriteDotNet.IO.Image;

--- a/source/AsepriteDotNet/Image/Spritesheet.cs
+++ b/source/AsepriteDotNet/Image/Spritesheet.cs
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
 using System.Collections.ObjectModel;
+using AsepriteDotNet.Common;
 using AsepriteDotNet.IO.Image;
 
 namespace AsepriteDotNet.Image;

--- a/source/AsepriteDotNet/Image/SpritesheetAnimation.cs
+++ b/source/AsepriteDotNet/Image/SpritesheetAnimation.cs
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
 using System.Collections.ObjectModel;
+using AsepriteDotNet.Common;
 
 namespace AsepriteDotNet.Image;
 

--- a/source/AsepriteDotNet/Image/SpritesheetFrame.cs
+++ b/source/AsepriteDotNet/Image/SpritesheetFrame.cs
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
 namespace AsepriteDotNet.Image;
 
 /// <summary>

--- a/source/AsepriteDotNet/Image/SprtesheetSlice.cs
+++ b/source/AsepriteDotNet/Image/SprtesheetSlice.cs
@@ -21,6 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
+
 namespace AsepriteDotNet.Image;
 
 /// <summary>

--- a/source/AsepriteDotNet/Image/Tilesheet.cs
+++ b/source/AsepriteDotNet/Image/Tilesheet.cs
@@ -23,6 +23,7 @@ SOFTWARE.
 ---------------------------------------------------------------------------- */
 using System.Collections;
 using System.Collections.ObjectModel;
+using AsepriteDotNet.Common;
 using AsepriteDotNet.IO.Image;
 
 namespace AsepriteDotNet.Image;

--- a/source/AsepriteDotNet/Image/TilesheetTile.cs
+++ b/source/AsepriteDotNet/Image/TilesheetTile.cs
@@ -21,6 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ---------------------------------------------------------------------------- */
+using AsepriteDotNet.Common;
+
 namespace AsepriteDotNet.Image;
 
 /// <summary>


### PR DESCRIPTION
Move `Color`, `Rectangle`, `Size`, and `Point` into a new namespace to avoid collisions with other libraries.