### PR TITLE
Added `ExtractCel` method to extract texture from individual cels

### DIFF
--- a/AsepriteDotNet.sln
+++ b/AsepriteDotNet.sln
@@ -58,6 +58,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProcessorExample", "example
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoGameExample", "examples\MonoGameExample\MonoGameExample.csproj", "{6FA09867-535B-4200-9D0A-88A2987BF033}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExtractCelExample", "examples\ExtractCelExample\ExtractCelExample.csproj", "{11D9BF92-538C-4B1D-B996-22E64F3F3ECF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -96,6 +98,10 @@ Global
 		{6FA09867-535B-4200-9D0A-88A2987BF033}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6FA09867-535B-4200-9D0A-88A2987BF033}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6FA09867-535B-4200-9D0A-88A2987BF033}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11D9BF92-538C-4B1D-B996-22E64F3F3ECF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11D9BF92-538C-4B1D-B996-22E64F3F3ECF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11D9BF92-538C-4B1D-B996-22E64F3F3ECF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11D9BF92-538C-4B1D-B996-22E64F3F3ECF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -110,6 +116,7 @@ Global
 		{E43B057B-37B4-4C77-AC25-376380318AEF} = {E55B2B0D-9615-434F-942A-6C496A02E617}
 		{DAD91498-F650-44C7-AAB8-A3454E084E5D} = {E55B2B0D-9615-434F-942A-6C496A02E617}
 		{6FA09867-535B-4200-9D0A-88A2987BF033} = {E55B2B0D-9615-434F-942A-6C496A02E617}
+		{11D9BF92-538C-4B1D-B996-22E64F3F3ECF} = {E55B2B0D-9615-434F-942A-6C496A02E617}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ABE689B5-F304-403F-A1E4-9973EB2F5FBD}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
         <NeutralLanguage>en</NeutralLanguage>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.5.0</Version>
+        <Version>1.6.0</Version>
     </PropertyGroup>
 
     <!-- Setup Code Analysis using the .editorconfig file -->

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A Cross Platform C# Library for Reading Aseprite Files
 
 [![main](https://github.com/AristurtleDev/AsepriteDotNet/actions/workflows/main.yml/badge.svg)](https://github.com/AristurtleDev/AsepriteDotNet/actions/workflows/main.yml)
-[![Nuget 1.5.0](https://img.shields.io/nuget/v/AsepriteDotNet?color=blue&style=flat-square)](https://www.nuget.org/packages/AsepriteDotNet/1.5.0)
+[![Nuget 1.6.0](https://img.shields.io/nuget/v/AsepriteDotNet?color=blue&style=flat-square)](https://www.nuget.org/packages/AsepriteDotNet/1.6.0)
 [![License: MIT](https://img.shields.io/badge/📃%20license-MIT-blue?style=flat)](LICENSE)
 [![Twitter](https://img.shields.io/badge/%20-Share%20On%20Twitter-555?style=flat&logo=twitter)](https://twitter.com/intent/tweet?text=AsepriteDotNet%20by%20%40aristurtledev%0A%0AA%20new%20cross-platform%20library%20in%20C%23%20for%20reading%20Aseprite%20.ase%2F.aseprite%20files.%20https%3A%2F%2Fgithub.com%2FAristurtleDev%2FAsepriteDotNet%0A%0A%23aseprite%20%23dotnet%20%23csharp%20%23oss%0A)
 </h1>
@@ -27,7 +27,7 @@ A Cross Platform C# Library for Reading Aseprite Files
 # Installation
 Install via NuGet
 ```
-dotnet add package AsepriteDotNet --version 1.5.0
+dotnet add package AsepriteDotNet --version 1.6.0
 ```
 
 # Usage

--- a/examples/ExtractCelExample/ExtractCelExample.csproj
+++ b/examples/ExtractCelExample/ExtractCelExample.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/examples/ExtractCelExample/Program.cs
+++ b/examples/ExtractCelExample/Program.cs
@@ -1,0 +1,7 @@
+﻿using AsepriteDotNet;
+using AsepriteDotNet.Aseprite;
+using AsepriteDotNet.IO;
+
+AsepriteFile aseFile = AsepriteFileLoader.FromFile("adventurer.aseprite");
+Texture head = aseFile.ExtractCel(0, "head");
+PngWriter.SaveTo("head.png", head.Size.Width, head.Size.Height, head.Pixels.ToArray());

--- a/source/AsepriteDotNet/Aseprite/AsepriteFile.Extensions.cs
+++ b/source/AsepriteDotNet/Aseprite/AsepriteFile.Extensions.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Christopher Whitley. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+using AsepriteDotNet.Aseprite.Types;
+
+namespace AsepriteDotNet.Aseprite;
+
+/// <summary>
+/// Provides extension methods for <see cref="AsepriteFile"/> instances.
+/// </summary>
+public static class AsepriteFileExtensions
+{
+    /// <summary>
+    /// Extracts pixel data from a specific cel in a specified frame of an <see cref="AsepriteFile"/> and returns it as
+    /// a <see cref="Texture"/>.
+    /// </summary>
+    /// <remarks>
+    /// Cel index of a frame starts at zero with the bottom most and goes up.  If a layer in a frame does not have cel
+    /// data, then the frame does not have that cel.  For instance, if your Aseprite file has 10 layers, but frame 0
+    /// does not have pixels on layer 2, then frame 0 will only have 9 cels and not the full 10 cels.
+    ///
+    /// Due to this, it may be easier to use the <see cref="ExtractCel(AsepriteFile, int, string, string?)"/> method
+    /// to specify the layer name to extract the cel from.
+    /// </remarks>
+    /// <param name="file">
+    /// The <see cref="AsepriteFile"/> containing the frame and cel from which to extract the pixel data.
+    /// </param>
+    /// <param name="frameIndex">
+    /// The index of the frame containing the cel from which to extract the pixel data.
+    /// </param>
+    /// <param name="celIndex">
+    /// The index of the cel within the specified frame from which to extract the pixel data.
+    /// </param>
+    /// <param name="name">
+    /// Optional name for the extracted texture. If not provided, a default name is generated.
+    /// </param>
+    /// <returns>A <see cref="Texture"/> object containing the extracted pixel data.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when the input <see cref="AsepriteFile"/> is null.</exception>
+    public static Texture ExtractCel(this AsepriteFile file, int frameIndex, int celIndex, string? name = null)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+        name ??= $"{file.Name}_frame{frameIndex}_cel{celIndex}";
+        AsepriteCel cel = file.Frames[frameIndex].Cels[celIndex];
+        return cel.ExtractCel(name);
+
+    }
+
+    /// <summary>
+    /// Extracts pixel data from a specific layer in a specified frame of an <see cref="AsepriteFile"/> and returns it
+    /// as a <see cref="Texture"/>.
+    /// </summary>
+    /// <param name="file">
+    /// The <see cref="AsepriteFile"/> containing the frame and layer from which to extract the pixel data.
+    /// </param>
+    /// <param name="frameIndex">The index of the frame from which to extract the pixel data.</param>
+    /// <param name="layerName">The name of the layer from which to extract the pixel data.</param>
+    /// <param name="name">Optional name for the extracted texture. If not provided, a default name is generated.</param>
+    /// <returns>A <see cref="Texture"/>. object containing the extracted pixel data.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when the input <see cref="AsepriteFile"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">Thrown when the specified layer cannot be located.</exception>
+    public static Texture ExtractCel(this AsepriteFile file, int frameIndex, string layerName, string? name = null)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+        name ??= $"{file.Name}_frame{frameIndex}_{layerName}_cel";
+        AsepriteCel? cel = null;
+        AsepriteFrame frame = file.Frames[frameIndex];
+        Parallel.For(0, frame.Cels.Length, new ParallelOptions() { MaxDegreeOfParallelism = Environment.ProcessorCount }, (i, loopState) =>
+        {
+            if (frame.Cels[i].Layer.Name.Equals(layerName, StringComparison.Ordinal))
+            {
+                cel = frame.Cels[i];
+                loopState.Break();
+            }
+        });
+
+        if (cel is null)
+        {
+            throw new ArgumentException($"Unable to locate cel in frame {frameIndex} on a layer called '{layerName}'", layerName);
+        }
+
+        return cel.ExtractCel(name);
+    }
+}

--- a/source/AsepriteDotNet/Aseprite/Types/AsepriteCel.Extensions.cs
+++ b/source/AsepriteDotNet/Aseprite/Types/AsepriteCel.Extensions.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Christopher Whitley. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+using AsepriteDotNet.Common;
+
+namespace AsepriteDotNet.Aseprite.Types;
+
+/// <summary>
+/// Provides extension methods for <see cref="AsepriteCel"/> instances.
+/// </summary>
+public static class AsepriteCelExtensions
+{
+    /// <summary>
+    /// Extracts pixel data from an <see cref="AsepriteCel"/> and returns it as a <see cref="Texture"/>.
+    /// </summary>
+    /// <param name="cel">The <see cref="AsepriteCel"/> containing the pixel data to extract.</param>
+    /// <param name="name">
+    /// Optional name for the extracted <see cref="Texture"/>. If not provided, an empty string is used.
+    /// </param>
+    /// <returns>A <see cref="Texture"/> object containing the extracted pixel data.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when the input <see cref="AsepriteCel"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the <see cref="AsepriteCel"/> does not contain pixel data.
+    /// </exception>
+    public static Texture ExtractCel(this AsepriteCel cel, string? name = null)
+    {
+        ArgumentNullException.ThrowIfNull(cel);
+
+
+        if (cel is AsepriteImageCel imageCel)
+        {
+            return imageCel.ExtractCel(name);
+        }
+
+        if (cel is AsepriteTilemapCel tilemapCel)
+        {
+            return tilemapCel.ExtractCel(name);
+        }
+
+        throw new InvalidOperationException("This cel does not contain pixel data");
+    }
+
+    {
+    /// <summary>
+    /// Extracts pixel data from an <see cref="AsepriteImageCel"/> and returns it as a <see cref="Texture"/>.
+    /// </summary>
+    /// <param name="cel">The <see cref="AsepriteImageCel"/> containing the pixel data to extract.</param>
+    /// <param name="name">
+    /// Optional name for the extracted <see cref="Texture"/>. If not provided, an empty string is used.
+    /// </param>
+    /// <returns>A <see cref="Texture"/> object containing the extracted pixel data.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when the input <see cref="AsepriteImageCel"/> is <see langword="null"/>.
+    /// </exception>
+    public static Texture ExtractCel(this AsepriteImageCel cel, string? name = null)
+    {
+        ArgumentNullException.ThrowIfNull(cel);
+
+        return new Texture(name ?? string.Empty, cel.Size, cel.Pixels.ToArray());
+    }
+
+    /// <summary>
+    /// Extracts pixel data from an <see cref="AsepriteTilemapCel"/> and returns it as a <see cref="Texture"/>.
+    /// </summary>
+    /// <param name="cel">The <see cref="AsepriteTilemapCel"/> containing the pixel data to extract.</param>
+    /// <param name="name">
+    /// Optional name for the extracted <see cref="Texture"/>. If not provided, an empty string is used.
+    /// </param>
+    /// <returns>A <see cref="Texture"/> object containing the extracted pixel data.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when the input <see cref="AsepriteTilemapCel"/> is <see langword="null"/>.
+    /// </exception>
+    public static Texture ExtractCel(this AsepriteTilemapCel cel, string? name = null)
+    {
+        ArgumentNullException.ThrowIfNull(cel);
+
+        AsepriteTilemapLayer layer = (AsepriteTilemapLayer)cel.Layer;
+        AsepriteTileset tileset = layer.Tileset;
+        Size size = new Size(cel.Size.Width * tileset.TileSize.Width, cel.Size.Height * tileset.TileSize.Height);
+        Rgba32[] pixels = new Rgba32[size.Width * size.Height];
+
+        Parallel.For(0, cel.Tiles.Length, new ParallelOptions() { MaxDegreeOfParallelism = Environment.ProcessorCount }, i =>
+        {
+            AsepriteTile tile = cel.Tiles[i];
+            int column = i % cel.Size.Width;
+            int row = i / cel.Size.Width;
+            Parallel.For(0, tileset.Pixels.Length, new ParallelOptions() { MaxDegreeOfParallelism = Environment.ProcessorCount }, j =>
+            {
+                int px = (j % tileset.TileSize.Width) + (column + tileset.TileSize.Height);
+                int py = (j / tileset.TileSize.Width) + (row + tileset.TileSize.Height);
+                int index = py * size.Width + px;
+                pixels[index] = tileset.Pixels[j];
+            });
+        });
+
+        return new Texture(name ?? string.Empty, size, pixels);
+    }
+}

--- a/source/AsepriteDotNet/Aseprite/Types/AsepriteCel.Extensions.cs
+++ b/source/AsepriteDotNet/Aseprite/Types/AsepriteCel.Extensions.cs
@@ -43,7 +43,6 @@ public static class AsepriteCelExtensions
         throw new InvalidOperationException("This cel does not contain pixel data");
     }
 
-    {
     /// <summary>
     /// Extracts pixel data from an <see cref="AsepriteImageCel"/> and returns it as a <see cref="Texture"/>.
     /// </summary>


### PR DESCRIPTION
## Prerequisites
- [x] I have verified that there are no existing pull requests that would overlap with this pull request.
- [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
- [x] I Have verified that this pull request adheres to this project's code of conduct.
- [x] I have written a descriptive title for this pull request.
- [ ] I have provided appropriate test coverage were applicable.

## Description
This pull request adds extension methods for `AsepriteFile` and `AsepriteCel` that allow consumers to extract the pixel data of an individual cel as a `Texture`.

## Related Issue Ticket Numbers
None

## References
This was created in reference to feedback from twitter https://x.com/Lojemiru/status/1772812588490887669?s=20
