### PR TITLE
Group Layer Tree Matching and Linked Cel Texture Extraction

### DIFF
--- a/source/AsepriteDotNet/Aseprite/Types/AsepriteCel.Extensions.cs
+++ b/source/AsepriteDotNet/Aseprite/Types/AsepriteCel.Extensions.cs
@@ -40,6 +40,11 @@ public static class AsepriteCelExtensions
             return tilemapCel.ExtractCel(name);
         }
 
+        if (cel is AsepriteLinkedCel linkedCel)
+        {
+            return linkedCel.Cel.ExtractCel(name);
+        }
+
         throw new InvalidOperationException("This cel does not contain pixel data");
     }
 

--- a/source/AsepriteDotNet/IO/AsepriteFileLoader.cs
+++ b/source/AsepriteDotNet/IO/AsepriteFileLoader.cs
@@ -219,8 +219,10 @@ public static partial class AsepriteFileLoader
         //  means of seeing why some data may not be what they expect it to be.
         List<string> warnings = new List<string>();
 
-        //  Reference to the last group layer that was read so that subsequent child layers can be added to it.
-        AsepriteGroupLayer? lastGroupLayer = null;
+        // References to the most recent previous group layers read by child level.
+        // Key: Child level of the group layer
+        // Value: Group layer
+        Dictionary<int, AsepriteGroupLayer> lastGroupsByChildLevel = new();
 
         //  Flag to determine if the palette has been read.  This is used to flag that a user data chunk is for the
         //  sprite due to changes in Aseprite 1.3
@@ -332,14 +334,14 @@ public static partial class AsepriteFileLoader
                                     throw new InvalidOperationException($"Unknown layer type: {properties.Type}");
                             }
 
-                            if (properties.Level != 0 && lastGroupLayer is not null)
+                            if (properties.Level != 0 && lastGroupsByChildLevel.TryGetValue(properties.Level - 1, out var group))
                             {
-                                lastGroupLayer.AddChild(layer);
+                                group.AddChild(layer);
                             }
 
                             if (layer is AsepriteGroupLayer groupLayer)
                             {
-                                lastGroupLayer = groupLayer;
+                                lastGroupsByChildLevel[groupLayer.ChildLevel] = groupLayer;
                             }
 
                             currentUserData = layer.UserData;


### PR DESCRIPTION
## Description
This pull request includes two relatively minor changes. One for the assignment of layers as children to group layers, and another for the extraction of textures from linked cels.

### 1. Group Layer Child Assignment
Previously, layers would always be added as children to the last-read group layer, regardless of their level relative to that group. As a result, layer structures like this:
```
A
. B
. C
... D
```
could end up looking more like this at runtime: 
```
A
. C
... D
..... B
```

This PR introduces a change that caches one last-read group layer per level. With this change, layers will be added to the last-read group layer whose level is one less than theirs, if such a group layer has previously been read. This should at least ensure that the actual hierarchy is preserved in more cases.

### 2. Linked Cel Texture Extraction
This PR also adds a simple check for linked cels in the `ExtractCel` extension for the `AsepriteCel` class. 
Instead of throwing an exception for instances of the `AsepriteLinkedCel` class, the extension will now extract the texture from the cel that a linked cel is linked to. While it is true that linked cels do not contain pixel data, the extension is more useful if automatically resolves the actual cel reference. 