### PR TITLE
Find linked cel by layer, not cel count

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
         <NeutralLanguage>en</NeutralLanguage>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.8.0</Version>
+        <Version>1.8.1</Version>
     </PropertyGroup>
 
     <!-- Setup Code Analysis using the .editorconfig file -->

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A Cross Platform C# Library for Reading Aseprite Files
 
 [![main](https://github.com/AristurtleDev/AsepriteDotNet/actions/workflows/main.yml/badge.svg)](https://github.com/AristurtleDev/AsepriteDotNet/actions/workflows/main.yml)
-[![Nuget 1.8.0](https://img.shields.io/nuget/v/AsepriteDotNet?color=blue&style=flat-square)](https://www.nuget.org/packages/AsepriteDotNet/1.8.0)
+[![Nuget 1.8.1](https://img.shields.io/nuget/v/AsepriteDotNet?color=blue&style=flat-square)](https://www.nuget.org/packages/AsepriteDotNet/1.8.1)
 [![License: MIT](https://img.shields.io/badge/📃%20license-MIT-blue?style=flat)](LICENSE)
 [![Twitter](https://img.shields.io/badge/%20-Share%20On%20Twitter-555?style=flat&logo=twitter)](https://twitter.com/intent/tweet?text=AsepriteDotNet%20by%20%40aristurtledev%0A%0AA%20new%20cross-platform%20library%20in%20C%23%20for%20reading%20Aseprite%20.ase%2F.aseprite%20files.%20https%3A%2F%2Fgithub.com%2FAristurtleDev%2FAsepriteDotNet%0A%0A%23aseprite%20%23dotnet%20%23csharp%20%23oss%0A)
 </h1>
@@ -27,7 +27,7 @@ A Cross Platform C# Library for Reading Aseprite Files
 # Installation
 Install via NuGet
 ```
-dotnet add package AsepriteDotNet --version 1.8.0
+dotnet add package AsepriteDotNet --version 1.8.1
 ```
 
 # Usage

--- a/source/AsepriteDotNet/IO/AsepriteFileLoader.cs
+++ b/source/AsepriteDotNet/IO/AsepriteFileLoader.cs
@@ -372,8 +372,23 @@ public static partial class AsepriteFileLoader
                                 case ASE_CEL_TYPE_LINKED:
                                     {
                                         ushort frameIndex = reader.ReadWord();
-                                        AsepriteCel otherCel = frames[frameIndex].Cels[cels.Count];
-                                        cel = new AsepriteLinkedCel(properties, otherCel);
+                                        AsepriteFrame originFrame = frames[frameIndex];
+                                        AsepriteCel? originCel = null;
+                                        for(int i = 0; i < originFrame.Cels.Length; i++)
+                                        {
+                                            if(originFrame.Cels[i].Layer == celLayer)
+                                            {
+                                                originCel = originFrame.Cels[i];
+                                                break;
+                                            }
+                                        }
+
+                                        if(originCel is null)
+                                        {
+                                            throw new InvalidOperationException("Unable to find origin cel for linked cel");
+                                        }
+
+                                        cel = new AsepriteLinkedCel(properties, originCel);
                                     }
                                     break;
 


### PR DESCRIPTION
## Prerequisites
- [x] I have verified that there are no existing pull requests that would overlap with this pull request.
- [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
- [x] I Have verified that this pull request adheres to this project's code of conduct.
- [x] I have written a descriptive title for this pull request.
- [x] I have provided appropriate test coverage were applicable.

## Description
Resolves issue when the frame that contains the origin of a linked cel contains less cels overall than a later frame that contains the linked cel.

## Related Issue Ticket Numbers
No issue, this was reported on discord
