### PR TITLE
Improve AsepriteBinaryReader and DeflateStream usage

### DIFF
--- a/source/AsepriteDotNet/Compression/Zlib.cs
+++ b/source/AsepriteDotNet/Compression/Zlib.cs
@@ -14,14 +14,10 @@ internal static class Zlib
     public static byte[] Deflate(byte[] buffer)
     {
         using MemoryStream compressedStream = new(buffer);
-
-        //  First 2 bytes are the zlib header information, skip past them.
-        _ = compressedStream.ReadByte();
-        _ = compressedStream.ReadByte();
-
         using MemoryStream decompressedStream = new();
-        using DeflateStream deflateStream = new(compressedStream, CompressionMode.Decompress);
-        deflateStream.CopyTo(decompressedStream);
+        using ZLibStream zlibStream = new(compressedStream, CompressionMode.Decompress);
+        zlibStream.CopyTo(decompressedStream);
+
         return decompressedStream.ToArray();
     }
 }

--- a/source/AsepriteDotNet/IO/PngWriter.cs
+++ b/source/AsepriteDotNet/IO/PngWriter.cs
@@ -92,7 +92,7 @@ public class PngWriter
     //  Bit Depth:
     //      1-byte integer that indicates the number of bits per sample. Valid
     //      values depend on the color type used
-    //      
+    //
     //       -----------------------------------------------
     //      | Color Type            |   Allowed bit depths  |
     //       -----------------------------------------------
@@ -128,8 +128,8 @@ public class PngWriter
     //
     //  Interlace Method:
     //      1-byte integer that indicates the transmission order of the image
-    //      data.  
-    //  
+    //      data.
+    //
     //       ---------------------------------------
     //      | Interlace Method          |   Value   |
     //       ---------------------------------------
@@ -159,7 +159,7 @@ public class PngWriter
     //  the compression stream.
     //
     //  The compression stream is a deflate stream including the Adler-32
-    //  trailer.  
+    //  trailer.
     //
     //  Each scanline of the image begins with a single byte that defines the
     //  filter used on that scanline.
@@ -215,13 +215,9 @@ public class PngWriter
 
         using MemoryStream ms = new();
 
-        //  Zlib deflate header for Default Compression
-        ms.WriteByte(0x78);
-        ms.WriteByte(0x9C);
-
         Adler32 adler = new();
 
-        using (DeflateStream deflate = new DeflateStream(ms, CompressionMode.Compress, leaveOpen: true))
+        using (ZLibStream deflate = new ZLibStream(ms, CompressionMode.Compress, leaveOpen: true))
         {
             ReadOnlySpan<byte> filter = stackalloc byte[1] { 0 };   //  Filter mode 0
             for (int i = 0; i < data.Length; i += width)
@@ -278,7 +274,7 @@ public class PngWriter
     //
     //  If there is no data (Length = 0), then the data chunk is not written
     //
-    //  Length: 
+    //  Length:
     //      A 4-byte unsigned integer giving the number of bytes in the chunk's
     //      data field. Only the data field. Do not include the length field
     //      itself, the chunk type field, or the crc field
@@ -329,12 +325,12 @@ public class PngWriter
 
 
     //  Per https://www.w3.org/TR/png-3/#7Integers-and-byte-order
-    //      
-    //      "All integers that require more than one byte shall be in network 
+    //
+    //      "All integers that require more than one byte shall be in network
     //      byte order"
     //
-    //  Basically, we have to ensure that all integer type values are in 
-    //  BigEndian.  
+    //  Basically, we have to ensure that all integer type values are in
+    //  BigEndian.
     //
     //  This method will check for endianess and convert to BigEndian if needed.
     private static int ToBigEndian(int value)

--- a/tests/AsepriteDotNet.Tests/IO/AsepriteBinaryReaderTests.cs
+++ b/tests/AsepriteDotNet.Tests/IO/AsepriteBinaryReaderTests.cs
@@ -42,8 +42,10 @@ namespace AsepriteDotNet.Tests.IO
             ValidateEndOfStreamException(writer => writer.Write(uint.MaxValue), reader => reader.ReadDword());
             ValidateEndOfStreamException(writer => writer.Write(int.MinValue), reader => reader.ReadLong());
             ValidateEndOfStreamException(writer => writer.Write(int.MaxValue), reader => reader.ReadLong());
-            ValidateEndOfStreamException(writer => writer.Write(float.MinValue), reader => reader.ReadFixed());
-            ValidateEndOfStreamException(writer => writer.Write(float.MaxValue), reader => reader.ReadFixed());
+            ValidateEndOfStreamException(writer => writer.Write(int.MinValue), reader => reader.ReadFixed());
+            ValidateEndOfStreamException(writer => writer.Write(int.MaxValue), reader => reader.ReadFixed());
+            ValidateEndOfStreamException(writer => writer.Write(float.MinValue), reader => reader.ReadFloat());
+            ValidateEndOfStreamException(writer => writer.Write(float.MaxValue), reader => reader.ReadFloat());
             ValidateEndOfStreamException(writer => WriteValidAsepriteString(writer, string.Empty), reader => reader.ReadString());
             ValidateEndOfStreamException(writer => WriteValidAsepriteString(writer, "Hello World"), reader => reader.ReadString());
         }
@@ -100,8 +102,17 @@ namespace AsepriteDotNet.Tests.IO
         [Fact]
         public void AsepriteBinaryReader_ReadFixed()
         {
-            ValidateRead(writer => writer.Write(float.MinValue), reader => reader.ReadFixed(), float.MinValue);
-            ValidateRead(writer => writer.Write(float.MaxValue), reader => reader.ReadFixed(), float.MaxValue);
+            const float minValue = int.MinValue / 65536.0f;
+            const float maxValue = int.MaxValue / 65536.0f;
+            ValidateRead(writer => writer.Write(int.MinValue), reader => reader.ReadFixed(), minValue);
+            ValidateRead(writer => writer.Write(int.MaxValue), reader => reader.ReadFixed(), maxValue);
+        }
+
+        [Fact]
+        public void AsepriteBinaryReader_ReadFloat()
+        {
+            ValidateRead(writer => writer.Write(float.MinValue), reader => reader.ReadFloat(), float.MinValue);
+            ValidateRead(writer => writer.Write(float.MaxValue), reader => reader.ReadFloat(), float.MaxValue);
         }
 
         [Fact]


### PR DESCRIPTION
## Prerequisites
- [x] I have verified that there are no existing pull requests that would overlap with this pull request.
- [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
- [x] I Have verified that this pull request adheres to this project's code of conduct.
- [x] I have written a descriptive title for this pull request.
- [x] I have provided appropriate test coverage were applicable.

## Description

#### Improvements to AsepriteBinaryReader
- Instead of a heap-allocated small buffer with `.AsSpan()`, use `stackalloc`
  - In this case where the buffer is very small, `stackalloc` is very fast
- Reconcile Aseprite's distinction between `fixed` and `float`:
  - Fixed point values are stored as 16:16 (that is, 16-bit integer and 16-bit fraction)
  - Floating point values are stored as single-precision IEEE values

#### DeflateStream to ZlibStream:
- Instances of DeflateStream now use ZlibStream
  - We can defer the responsibility of handling the header to the .NET standard library

#### Non-functional changes:
- Documentation grammar

## Related Issue Ticket Numbers
- n/a
