### PR TITLE
Initialize FrameIndex in AsepriteSliceKey constructor.

### DIFF
--- a/source/AsepriteDotNet/Aseprite/Types/AsepriteSliceKey.cs
+++ b/source/AsepriteDotNet/Aseprite/Types/AsepriteSliceKey.cs
@@ -34,6 +34,8 @@ public sealed class AsepriteSliceKey
 
     internal AsepriteSliceKey(AsepriteSliceKeyProperties keyProperties, AsepriteNinePatchProperties? ninePatchProperties, AsepritePivotProperties? pivotProperties)
     {
+        FrameIndex = (int)keyProperties.FrameNumber;
+
         Bounds = new Rectangle((int)keyProperties.X, (int)keyProperties.Y, (int)keyProperties.Width, (int)keyProperties.Height);
 
         //  If this is not a nine patch, make the center bounds equal to the key bounds.


### PR DESCRIPTION
## Prerequisites
- [x] I have verified that there are no existing pull requests that would overlap with this pull request.
- [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
- [x] I Have verified that this pull request adheres to this project's code of conduct.
- [x] I have written a descriptive title for this pull request.
- [ ] I have provided appropriate test coverage were applicable.

## Description
<!-- A description of the changes proposed in the pull-request -->
AsepriteSliceKey constructor was not assigning FrameIndex. It was being passed by parameter but not being used. This should enable to use slices that have different positions through different frames
## Related Issue Ticket Numbers
<!-- Provided a bulleted list of related issues in this project this pull request is addressing, if any -->
Slices worked correctly, unless these were Slices that had different positions on different frames.