### PR TITLE
Allow specification of layers when flattening frame

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
         <NeutralLanguage>en</NeutralLanguage>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.8.3</Version>
+        <Version>1.9.0</Version>
     </PropertyGroup>
 
     <!-- Setup Code Analysis using the .editorconfig file -->

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A Cross Platform C# Library for Reading Aseprite Files
 
 [![main](https://github.com/AristurtleDev/AsepriteDotNet/actions/workflows/main.yml/badge.svg)](https://github.com/AristurtleDev/AsepriteDotNet/actions/workflows/main.yml)
-[![Nuget 1.8.3](https://img.shields.io/nuget/v/AsepriteDotNet?color=blue&style=flat-square)](https://www.nuget.org/packages/AsepriteDotNet/1.8.3)
+[![Nuget 1.9.0](https://img.shields.io/nuget/v/AsepriteDotNet?color=blue&style=flat-square)](https://www.nuget.org/packages/AsepriteDotNet/1.9.0)
 [![License: MIT](https://img.shields.io/badge/📃%20license-MIT-blue?style=flat)](LICENSE)
 [![Twitter](https://img.shields.io/badge/%20-Share%20On%20Twitter-555?style=flat&logo=twitter)](https://twitter.com/intent/tweet?text=AsepriteDotNet%20by%20%40aristurtledev%0A%0AA%20new%20cross-platform%20library%20in%20C%23%20for%20reading%20Aseprite%20.ase%2F.aseprite%20files.%20https%3A%2F%2Fgithub.com%2FAristurtleDev%2FAsepriteDotNet%0A%0A%23aseprite%20%23dotnet%20%23csharp%20%23oss%0A)
 </h1>
@@ -27,7 +27,7 @@ A Cross Platform C# Library for Reading Aseprite Files
 # Installation
 Install via NuGet
 ```
-dotnet add package AsepriteDotNet --version 1.8.3
+dotnet add package AsepriteDotNet --version 1.9.0
 ```
 
 # Usage

--- a/examples/ProcessorExample/Program.cs
+++ b/examples/ProcessorExample/Program.cs
@@ -11,24 +11,24 @@ using AsepriteDotNet.Processors;
 ///
 /// Load the file using the AsepriteFileLoader.  In this example, we are passing the path to the file.  There is also
 /// an overload where you can pass a stream instead if you needed.
-/// 
+///
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 AsepriteFile aseFile = AsepriteFileLoader.FromFile("adventurer.aseprite");
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///
-/// Create the process options to use with the processors.  Here we use the default options, however you an customize
-/// them.  See the README documentation for available properties and what each does for the processor options.
-/// 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-ProcessorOptions options = ProcessorOptions.Default;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ///
-/// The SpriteProcesor is used to process a Sprite from a single frame
-/// 
+/// The SpriteProcessor is used to process a Sprite from a single frame
+///
+/// The onlyVisibleLayers, includeBackgroundLayer, and includeTilemapLayers parameters are optional. Below shows their
+/// default values if not specified.
+///
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-Sprite sprite = SpriteProcessor.Process(aseFile, 0, options);
+Sprite sprite = SpriteProcessor.Process(aseFile,
+                                        0,
+                                        onlyVisibleLayers: true,
+                                        includeBackgroundLayer: false,
+                                        includeTilemapLayers: false);
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ///
@@ -36,15 +36,35 @@ Sprite sprite = SpriteProcessor.Process(aseFile, 0, options);
 /// image representation of all frames in the Aseprite file that have been box packed into the pixel data.  Additional
 /// TextureRegion properties are provided that define the source rectangle for each frame within the base texture
 /// representation.
-/// 
+///
+/// The onlyVisibleLayers, includeBackgroundLayer, includeTileMapLayers, mergeDuplicateFrames, borderPadding, spacing,
+/// and innerPadding parameters are optional.  Below shows their default values when not specified.
+///
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-TextureAtlas atals = TextureAtlasProcessor.Process(aseFile, options);
+TextureAtlas atlas = TextureAtlasProcessor.Process(aseFile,
+                                                   onlyVisibleLayers: true,
+                                                   includeBackgroundLayer: false,
+                                                   includeTilemapLayers: false,
+                                                   mergeDuplicateFrames: true,
+                                                   borderPadding: 0,
+                                                   spacing: 0,
+                                                   innerPadding: 0);
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ///
 /// The SpriteSheet processor will process a SpriteSheet from the aseprite file.  A SpriteSheet uses a TextureAtlas as
 /// its source for the image and provides additional properties that define animations as defined by the tags in
 /// Aseprite.
-/// 
+///
+/// The onlyVisibleLayers, includeBackgroundLayer, includeTileMapLayers, mergeDuplicateFrames, borderPadding, spacing,
+/// and innerPadding parameters are optional.  Below shows their default values when not specified.
+///
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-SpriteSheet spriteSheet = SpriteSheetProcessor.Process(aseFile, options);
+SpriteSheet spriteSheet = SpriteSheetProcessor.Process(aseFile,
+                                                       onlyVisibleLayers: true,
+                                                       includeBackgroundLayer: false,
+                                                       includeTilemapLayers: false,
+                                                       mergeDuplicateFrames: true,
+                                                       borderPadding: 0,
+                                                       spacing: 0,
+                                                       innerPadding: 0);

--- a/source/AsepriteDotNet/AnimatedTilemap.cs
+++ b/source/AsepriteDotNet/AnimatedTilemap.cs
@@ -12,6 +12,12 @@ namespace AsepriteDotNet;
 /// </summary>
 public sealed class AnimatedTilemap : IEquatable<AnimatedTilemap>
 {
+    /// <summary>
+    /// An empty animated tilemap with no name, an empty collection of tilesets, and an empty collection of tilemap
+    /// frames.
+    /// </summary>
+    public static readonly AnimatedTilemap Empty = new AnimatedTilemap(string.Empty, Array.Empty<Tileset>(), Array.Empty<TilemapFrame>());
+
     private readonly Tileset[] _tilests;
     private readonly TilemapFrame[] _frames;
 

--- a/source/AsepriteDotNet/Aseprite/AsepriteFile.cs
+++ b/source/AsepriteDotNet/Aseprite/AsepriteFile.cs
@@ -152,7 +152,7 @@ public sealed class AsepriteFile
     /// </summary>
     /// <param name="name">The name of <see cref="AsepriteLayer"/>.</param>
     /// <returns>The <see cref="AsepriteLayer"/> with the specified name.</returns>
-    /// <exception cref="ArgumentException">
+    /// <exception cref="ArgumentNullException">
     /// If <paramref name="name"/> is <see langword="null"/> or an empty string.
     /// </exception>
     /// <exception cref="InvalidOperationException">
@@ -163,10 +163,10 @@ public sealed class AsepriteFile
 #if NET6_0
         if(string.IsNullOrEmpty(name))
         {
-            throw new ArgumentException(nameof(name));
+            throw new ArgumentNullException(nameof(name), $"{nameof(name)} cannot be null or an empty string.");
         }
 #elif NET8_0_OR_GREATER
-        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentNullException.ThrowIfNullOrEmpty(name);
 #endif
 
         return _layers.AsParallel()
@@ -231,7 +231,7 @@ public sealed class AsepriteFile
     /// </summary>
     /// <param name="name">The name of <see cref="AsepriteTag"/>.</param>
     /// <returns>The <see cref="AsepriteTag"/> with the specified name.</returns>
-    /// <exception cref="ArgumentException">
+    /// <exception cref="ArgumentNullException">
     /// If <paramref name="name"/> is <see langword="null"/> or an empty string.
     /// </exception>
     /// <exception cref="InvalidOperationException">
@@ -242,10 +242,10 @@ public sealed class AsepriteFile
 #if NET6_0
         if(string.IsNullOrEmpty(name))
         {
-            throw new ArgumentException(nameof(name));
+            throw new ArgumentNullException(nameof(name), $"{nameof(name)} cannot be null or an empty string");
         }
 #elif NET8_0_OR_GREATER
-        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentNullException.ThrowIfNullOrEmpty(name);
 #endif
 
         return _tags.AsParallel()
@@ -310,7 +310,7 @@ public sealed class AsepriteFile
     /// </summary>
     /// <param name="name">The name of <see cref="AsepriteSlice"/>.</param>
     /// <returns>The <see cref="AsepriteSlice"/> with the specified name.</returns>
-    /// <exception cref="ArgumentException">
+    /// <exception cref="ArgumentNullException">
     /// If <paramref name="name"/> is <see langword="null"/> or an empty string.
     /// </exception>
     /// <exception cref="InvalidOperationException">
@@ -321,10 +321,10 @@ public sealed class AsepriteFile
 #if NET6_0
         if(string.IsNullOrEmpty(name))
         {
-            throw new ArgumentException(nameof(name));
+            throw new ArgumentNullException(nameof(name), $"{nameof(name)} cannot be null or an empty string");
         }
 #elif NET8_0_OR_GREATER
-        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentNullException.ThrowIfNullOrEmpty(name);
 #endif
 
         return _slices.AsParallel()
@@ -389,7 +389,7 @@ public sealed class AsepriteFile
     /// </summary>
     /// <param name="name">The name of <see cref="AsepriteTileset"/>.</param>
     /// <returns>The <see cref="AsepriteTileset"/> with the specified name.</returns>
-    /// <exception cref="ArgumentException">
+    /// <exception cref="ArgumentNullException">
     /// If <paramref name="name"/> is <see langword="null"/> or an empty string.
     /// </exception>
     /// <exception cref="InvalidOperationException">
@@ -400,10 +400,10 @@ public sealed class AsepriteFile
 #if NET6_0
         if(string.IsNullOrEmpty(name))
         {
-            throw new ArgumentException(nameof(name));
+            throw new ArgumentNullException(nameof(name), $"{nameof(name)} cannot be null or an empty string");
         }
 #elif NET8_0_OR_GREATER
-        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentNullException.ThrowIfNullOrEmpty(name);
 #endif
 
         return _tilesets.AsParallel()

--- a/source/AsepriteDotNet/Aseprite/Types/AsepriteFrame.Extensions.cs
+++ b/source/AsepriteDotNet/Aseprite/Types/AsepriteFrame.Extensions.cs
@@ -139,8 +139,8 @@ public static class AsepriteFrameExtensions
 
         AsepriteTileset tileset = aseTilemapLayer.Tileset;
         Rectangle bounds;
-        bounds.Width = cel.Size.Width * tileset.Size.Width;
-        bounds.Height = cel.Size.Height * tileset.Size.Height;
+        bounds.Width = cel.Size.Width * tileset.TileSize.Width;
+        bounds.Height = cel.Size.Height * tileset.TileSize.Height;
         bounds.X = cel.Location.X;
         bounds.Y = cel.Location.Y;
 
@@ -155,8 +155,8 @@ public static class AsepriteFrameExtensions
 
             for (int j = 0; j < tilePixels.Length; j++)
             {
-                int px = (j % tileset.Size.Width) + (column * tileset.Size.Height);
-                int py = (j / tileset.Size.Width) + (row * tileset.Size.Height);
+                int px = (j % tileset.TileSize.Width) + (column * tileset.TileSize.Height);
+                int py = (j / tileset.TileSize.Width) + (row * tileset.TileSize.Height);
                 int index = py * bounds.Width + px;
                 pixels[index] = tilePixels[j];
             }

--- a/source/AsepriteDotNet/Aseprite/Types/AsepriteFrame.Extensions.cs
+++ b/source/AsepriteDotNet/Aseprite/Types/AsepriteFrame.Extensions.cs
@@ -17,6 +17,52 @@ public static class AsepriteFrameExtensions
     /// Flattens the a <see cref="AsepriteFrame"/> into an array of <see cref="Rgba32"/> values.
     /// </summary>
     /// <param name="frame">The <see cref="AsepriteFrame"/> to flatten.</param>
+    /// <param name="layers">The layers to include (case sensitive)</param>
+    /// <returns>
+    /// A array of <see cref="Rgba32"/> value representing the flattened frame.  If <paramref name="layers"/> is
+    /// <see langword="null"/> or contains zero elements, then an empty array is returned.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="frame"/> is <see langword="null"/>.</exception>
+    public static Rgba32[] FlattenFrame(this AsepriteFrame frame, ICollection<string> layers)
+    {
+        ArgumentNullException.ThrowIfNull(frame);
+        if (layers is null || layers.Count == 0)
+        {
+            return Array.Empty<Rgba32>();
+        }
+
+        Rgba32[] result = new Rgba32[frame.Size.Width * frame.Size.Height];
+        HashSet<string> layerNames = new HashSet<string>(layers);
+        ReadOnlySpan<AsepriteCel> cels = frame.Cels;
+
+        for (int celNum = 0; celNum < cels.Length; celNum++)
+        {
+            AsepriteCel cel = cels[celNum];
+
+            if (!layerNames.Contains(cel.Layer.Name)) { continue; }
+
+            if (cel is AsepriteLinkedCel linkedCel)
+            {
+                cel = linkedCel.Cel;
+            }
+
+            if (cel is AsepriteImageCel imageCel)
+            {
+                BlendCel(result, imageCel.Pixels, imageCel.Layer.BlendMode, new Rectangle(imageCel.Location, imageCel.Size), frame.Size.Width, imageCel.Opacity, imageCel.Layer.Opacity);
+            }
+            else if (cel is AsepriteTilemapCel tilemapCel)
+            {
+                BlendTilemapCel(result, tilemapCel, frame.Size.Width);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Flattens the a <see cref="AsepriteFrame"/> into an array of <see cref="Rgba32"/> values.
+    /// </summary>
+    /// <param name="frame">The <see cref="AsepriteFrame"/> to flatten.</param>
     /// <param name="onlyVisibleLayers">Indicates whether only cels on visible layers should be included.</param>
     /// <param name="includeBackgroundLayer">Indicates whether cels on the background layer should be included.</param>
     /// <param name="includeTilemapCels">Indicates whether tilemap cels should be included.</param>
@@ -26,12 +72,15 @@ public static class AsepriteFrameExtensions
     {
         ArgumentNullException.ThrowIfNull(frame);
 
+        List<AsepriteLayer> layers = new List<AsepriteLayer>();
+
         Rgba32[] result = new Rgba32[frame.Size.Width * frame.Size.Height];
         ReadOnlySpan<AsepriteCel> cels = frame.Cels;
 
         for (int celNum = 0; celNum < cels.Length; celNum++)
         {
             AsepriteCel cel = cels[celNum];
+
             if (cel is AsepriteLinkedCel linkedCel)
             {
                 cel = linkedCel.Cel;
@@ -64,9 +113,9 @@ public static class AsepriteFrameExtensions
         //
         //  So we need to determine the starting and ending xy-coordinate locations within the pixels of the
         //  cel (backdrop) that are within the frame bounds so we only process those.
-        int startX = Math.Max(0, -bounds.X); 
-        int startY = Math.Max(0, -bounds.Y); 
-        int endX = Math.Min(bounds.Width, frameWidth - bounds.X); 
+        int startX = Math.Max(0, -bounds.X);
+        int startY = Math.Max(0, -bounds.Y);
+        int endX = Math.Min(bounds.Width, frameWidth - bounds.X);
         int endY = Math.Min(bounds.Height, backdrop.Length / frameWidth - bounds.Y);
 
         for (int y = startY; y < endY; y++)

--- a/source/AsepriteDotNet/Compression/CRC.cs
+++ b/source/AsepriteDotNet/Compression/CRC.cs
@@ -14,7 +14,7 @@ internal class CRC
     /// </summary>
     public const uint DEFAULT = 0xFFFFFFFF;
 
-    private static readonly uint[] _crcTable;
+    private static readonly uint[] _crcTable = new uint[256];
 
     private uint _value;
 
@@ -48,8 +48,6 @@ internal class CRC
 
         //  Make the table for fast crc
         //  https://www.w3.org/TR/2003/REC-PNG-20031110/#D-CRCAppendix
-        _crcTable = new uint[256];
-
         uint c;
         for (uint n = 0; n < 256; n++)
         {

--- a/source/AsepriteDotNet/IO/AsepriteBinaryReader.cs
+++ b/source/AsepriteDotNet/IO/AsepriteBinaryReader.cs
@@ -320,7 +320,7 @@ internal sealed class AsepriteBinaryReader : IDisposable
     /// Thrown if the end of stream was reached when attempting to read.
     /// </exception>
     /// <exception cref="InvalidOperationException">
-    /// Thrown if an exception occurs during the internal call to <see cref="Marshal.PtrToStructure{T}(nint)"/>.  See
+    /// Thrown if an exception occurs while attempting to map the type ot the <typeparamref name="T"/> struct. See the
     /// inner exception for details.
     /// </exception>
     public T ReadUnsafe<T>(int structSize) where T : struct

--- a/source/AsepriteDotNet/IO/PngException.cs
+++ b/source/AsepriteDotNet/IO/PngException.cs
@@ -14,6 +14,8 @@ namespace AsepriteDotNet.IO;
 /// </remarks>
 public class PngException : Exception
 {
+    internal PngException():base() {}
+    internal PngException(string message):base(message) {}
     internal PngException(string message, Exception innerException)
         : base(message, innerException) { }
 }

--- a/source/AsepriteDotNet/IO/PngWriter.cs
+++ b/source/AsepriteDotNet/IO/PngWriter.cs
@@ -15,7 +15,7 @@ namespace AsepriteDotNet.IO;
 /// <summary>
 /// Write <see cref="Rgba32"/> color data to a png file.
 /// </summary>
-public class PngWriter
+public static class PngWriter
 {
     //  Common IDAT chunk sizes are between 8 and 32 Kib.  Opting to use
     //  8Kib for this project.
@@ -30,6 +30,8 @@ public class PngWriter
     /// <param name="data">The color data of the image.</param>
     public static void SaveTo(string path, int width, int height, Rgba32[] data)
     {
+        ArgumentNullException.ThrowIfNull(data);
+
         try
         {
             using FileStream fs = File.OpenWrite(path);

--- a/source/AsepriteDotNet/Processors/AnimatedTilemapProcessor.cs
+++ b/source/AsepriteDotNet/Processors/AnimatedTilemapProcessor.cs
@@ -21,13 +21,64 @@ public static class AnimatedTilemapProcessor
     /// Optional options to use when processing.  If <see langword="null"/>, then
     /// <see cref="ProcessorOptions.Default"/> will be used.
     /// </param>
-    /// <returns>The <see cref="AnimatedTilemap"/>.</returns>
+    /// <returns>The <see cref="AnimatedTilemap"/> created by this method.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="file"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException">Thrown when duplicate layer names are found.</exception>
+    [Obsolete("This method will be removed in a future release.  Users should switch to one of the other appropriate Process methods", false)]
     public static AnimatedTilemap Process(AsepriteFile file, ProcessorOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(file);
         options ??= ProcessorOptions.Default;
+
+        return Process(file, options.OnlyVisibleLayers);
+    }
+
+    /// <summary>
+    /// Processes an <see cref="AnimatedTilemap"/> from an <see cref="AsepriteFile"/>.
+    /// </summary>
+    /// <param name="file">The <see cref="AsepriteFile"/> to process.</param>
+    /// <param name="onlyVisibleLayers">Indicates whether only visible layers should be processed.</param>
+    /// <returns>The <see cref="AnimatedTilemap"/> created by this method.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="file"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when duplicate layer names are found.</exception>
+    public static AnimatedTilemap Process(AsepriteFile file, bool onlyVisibleLayers = true)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+
+        List<string> layers = new List<string>();
+        for (int i = 0; i < file.Layers.Length; i++)
+        {
+            AsepriteLayer layer = file.Layers[i];
+            if (layer is not AsepriteTilemapLayer) { continue; }
+            if (onlyVisibleLayers && !layer.IsVisible) { continue; }
+            layers.Add(layer.Name);
+        }
+
+        return Process(file, layers);
+    }
+
+    /// <summary>
+    /// Processes an <see cref="AnimatedTilemap"/> from an <see cref="AsepriteFile"/>.
+    /// </summary>
+    /// <param name="file"></param>
+    /// <param name="layers">
+    /// A collection containing the name of the layers to process.  Only cels on a layer who's name matches a name in
+    /// this collection will be processed.
+    /// </param>
+    /// <returns>
+    /// The <see cref="AnimatedTilemap"/> created by this method.  If <paramref name="layers"/> is empty or contains zero
+    /// elements, then <see cref="AnimatedTilemap.Empty"/> is returned.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="file"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when duplicate layer names are found.</exception>
+    public static AnimatedTilemap Process(AsepriteFile file, ICollection<string> layers)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+
+        if (layers is null || layers.Count == 0)
+        {
+            return AnimatedTilemap.Empty;
+        }
 
         List<Tileset> tilesets = new List<Tileset>();
         TilemapFrame[] frames = new TilemapFrame[file.Frames.Length];
@@ -44,11 +95,10 @@ public static class AnimatedTilemapProcessor
                 //  Only care about tilemap cels
                 if (aseFrame.Cels[c] is not AsepriteTilemapCel aseTilemapCel) { continue; }
 
-                //  Only continue if layer is visible or if explicitly told to include non-visible layers
-                if (!aseTilemapCel.Layer.IsVisible && options.OnlyVisibleLayers) { continue; }
-
                 Debug.Assert(aseTilemapCel.Layer is AsepriteTilemapLayer);
                 AsepriteTilemapLayer aseTilemapLayer = (AsepriteTilemapLayer)aseTilemapCel.Layer;
+
+                if (!layers.Contains(aseTilemapLayer.Name)) { continue; }
 
                 //  Need to perform a check that we don't have duplicate layer names.  This is because Aseprite allows
                 //  duplicate layer names, be we require unique names from this point on.

--- a/source/AsepriteDotNet/Processors/ProcessorOptions.cs
+++ b/source/AsepriteDotNet/Processors/ProcessorOptions.cs
@@ -14,6 +14,7 @@ namespace AsepriteDotNet.Processors;
 /// <param name="BorderPadding">The amount of transparent pixels to add to the edge of the generated texture.</param>
 /// <param name="Spacing">The amount of transparent pixels to add between each texture region in the generated texture.</param>
 /// <param name="InnerPadding">The amount of transparent pixels to add around the edge of each texture region in the generated texture.</param>
+[Obsolete("ProcessorOptions will be removed in a future release.  Users should switch to one of the Process method overloads that does not require an instance of these options", false)]
 public record ProcessorOptions(bool OnlyVisibleLayers,
                                            bool IncludeBackgroundLayer,
                                            bool IncludeTilemapLayers,
@@ -59,6 +60,7 @@ public record ProcessorOptions(bool OnlyVisibleLayers,
     ///     </item>
     /// </list>
     /// </summary>
+    [Obsolete("ProcessorOptions will be removed in a future release.  Users should switch to one of the Process method overloads that does not require an instance of these options", false)]
     public static readonly ProcessorOptions Default = new ProcessorOptions(true, false, true, true, 0, 0, 0);
 }
 

--- a/source/AsepriteDotNet/Processors/SpriteProcessor.cs
+++ b/source/AsepriteDotNet/Processors/SpriteProcessor.cs
@@ -19,6 +19,10 @@ public static class SpriteProcessor
     /// </summary>
     /// <param name="file">The <see cref="AsepriteFile"/> to process the frame from.</param>
     /// <param name="frameIndex">The zero-based index of the frame to process.</param>
+    /// <param name="options">
+    /// Optional options to use when processing.  If <see langword="null"/>, then
+    /// <see cref="ProcessorOptions.Default"/> will be used.
+    /// </param>
     /// <returns>The <see cref="Sprite"/> created by this method.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="file"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">

--- a/source/AsepriteDotNet/Processors/SpriteProcessor.cs
+++ b/source/AsepriteDotNet/Processors/SpriteProcessor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 // See LICENSE file in the project root for full license information.
 
+using System.Runtime.Versioning;
 using AsepriteDotNet.Aseprite;
 using AsepriteDotNet.Aseprite.Types;
 using AsepriteDotNet.Common;
@@ -24,17 +25,78 @@ public static class SpriteProcessor
     /// Thrown when <paramref name="frameIndex"/> is less than zero or is greater than or equal to the total number of
     /// frames in the file.
     /// </exception>
+    [Obsolete("This method will be removed in a future release.  Users should switch to one of the other appropriate Process methods", false)]
     public static Sprite Process(AsepriteFile file, int frameIndex, ProcessorOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(file);
         options ??= ProcessorOptions.Default;
 
+        return Process(file, frameIndex, options.OnlyVisibleLayers, options.IncludeBackgroundLayer, options.IncludeTilemapLayers);
+
+    }
+
+    /// <summary>
+    /// Processes a frame from an <see cref="AsepriteFile"/> as a <see cref="Sprite"/>.
+    /// </summary>
+    /// <param name="file">The <see cref="AsepriteFile"/> to process the frame from.</param>
+    /// <param name="frameIndex">The zero-based index of the frame to process.</param>
+    /// <param name="onlyVisibleLayers">Indicates whether only visible layers should be processed.</param>
+    /// <param name="includeBackgroundLayer">Indicates whether the layer assigned as the background layer should be processed.</param>
+    /// <param name="includeTilemapLayers">Indicates whether tilemap layers should be processed.</param>>
+    /// <returns>The <see cref="Sprite"/> created by this method.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="file"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="frameIndex"/> is less than zero or is greater than or equal to the total number of
+    /// frames in the file.
+    /// </exception>
+    public static Sprite Process(AsepriteFile file, int frameIndex, bool onlyVisibleLayers = true, bool includeBackgroundLayer = false, bool includeTilemapLayers = false)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+
+        List<string> layers = new List<string>();
+        for (int i = 0; i < file.Layers.Length; i++)
+        {
+            AsepriteLayer layer = file.Layers[i];
+            if (onlyVisibleLayers && !layer.IsVisible) { continue; }
+            if (!includeBackgroundLayer && layer.IsBackgroundLayer) { continue; }
+            if (!includeTilemapLayers && layer is AsepriteTilemapLayer) { continue; }
+            layers.Add(layer.Name);
+        }
+
+        return Process(file, frameIndex, layers);
+    }
+
+    /// <summary>
+    /// Processes a frame from an <see cref="AsepriteFile"/> as a <see cref="Sprite"/>.
+    /// </summary>
+    /// <param name="file">The <see cref="AsepriteFile"/> to process the frame from.</param>
+    /// <param name="frameIndex">The zero-based index of the frame to process.</param>
+    /// <param name="layers">
+    /// A collection containing the name of the layers to process.  Only cels on a layer who's name matches a name in
+    /// this collection will be processed.
+    /// </param>
+    /// <returns>
+    /// The <see cref="Sprite"/> created by this method.  If <paramref name="layers"/> is empty or contains zero
+    /// elements, then <see cref="Sprite.Empty"/> is returned.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="file"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="frameIndex"/> is less than zero or is greater than or equal to the total number of
+    /// frames in the file.
+    /// </exception>
+    public static Sprite Process(AsepriteFile file, int frameIndex, ICollection<string> layers)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+
+        if (layers is null || layers.Count == 0)
+        {
+            return Sprite.Empty;
+        }
+
         AsepriteFrame aseFrame = file.Frames[frameIndex];
-        Rgba32[] pixels = aseFrame.FlattenFrame(options.OnlyVisibleLayers, options.IncludeBackgroundLayer, options.IncludeTilemapLayers);
+        Rgba32[] pixels = aseFrame.FlattenFrame(layers);
         Texture texture = new Texture(aseFrame.Name, aseFrame.Size, pixels);
         Slice[] slices = ProcessorUtilities.GetSlicesForFrame(frameIndex, file.Slices);
         return new Sprite(aseFrame.Name, texture, slices);
     }
-
-    
 }

--- a/source/AsepriteDotNet/Processors/SpriteSheetProcessor.cs
+++ b/source/AsepriteDotNet/Processors/SpriteSheetProcessor.cs
@@ -23,12 +23,95 @@ public static class SpriteSheetProcessor
     /// <returns>The <see cref="SpriteSheet"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="file"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException">Thrown when duplicate tag names are found.</exception>
+    [Obsolete("This method will be removed in a future release.  Users should switch to one of the other appropriate Process methods", false)]
     public static SpriteSheet Process(AsepriteFile file, ProcessorOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(file);
         options ??= ProcessorOptions.Default;
 
         TextureAtlas textureAtlas = TextureAtlasProcessor.Process(file, options);
+        AnimationTag[] tags = new AnimationTag[file.Tags.Length];
+        HashSet<string> tagNameCheck = new HashSet<string>();
+
+        for (int i = 0; i < file.Tags.Length; i++)
+        {
+            AsepriteTag aseTag = file.Tags[i];
+            if (!tagNameCheck.Add(aseTag.Name))
+            {
+                throw new InvalidOperationException($"Duplicate tag name '{aseTag.Name}' found.  Tags must have unique names for a sprite sheet");
+            }
+
+            tags[i] = ProcessTag(aseTag, file.Frames);
+        }
+
+        return new SpriteSheet(file.Name, textureAtlas, tags);
+    }
+
+    /// <summary>
+    /// Processes a <see cref="SpriteSheet"/> from an <see cref="AsepriteFile"/>.
+    /// </summary>
+    /// <param name="file">The <see cref="AsepriteFile"/> to process.</param>
+    /// <param name="onlyVisibleLayers">Indicates whether only visible layers should be processed.</param>
+    /// <param name="includeBackgroundLayer">Indicates whether the layer assigned as the background layer should be processed.</param>
+    /// <param name="includeTilemapLayers">Indicates whether tilemap layers should be processed.</param>
+    /// <param name="mergeDuplicateFrames">Indicates whether duplicates frames should be merged.</param>
+    /// <param name="borderPadding">The amount of transparent pixels to add to the edge of the generated texture.</param>
+    /// <param name="spacing">The amount of transparent pixels to add between each texture region in the generated texture.</param>
+    /// <param name="innerPadding">The amount of transparent pixels to add around the edge of each texture region in the generated texture.</param>
+    /// <returns>The <see cref="SpriteSheet"/> created by this method.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="file"/> is <see langword="null"/>.</exception>
+    public static SpriteSheet Process(AsepriteFile file,
+                                       bool onlyVisibleLayers = true,
+                                       bool includeBackgroundLayer = false,
+                                       bool includeTilemapLayers = false,
+                                       bool mergeDuplicateFrames = true,
+                                       int borderPadding = 0,
+                                       int spacing = 0,
+                                       int innerPadding = 0)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+
+        List<string> layers = new List<string>();
+        for (int i = 0; i < file.Layers.Length; i++)
+        {
+            AsepriteLayer layer = file.Layers[i];
+            if (onlyVisibleLayers && !layer.IsVisible) { continue; }
+            if (!includeBackgroundLayer && layer.IsBackgroundLayer) { continue; }
+            if (!includeTilemapLayers && layer is AsepriteTilemapLayer) { continue; }
+            layers.Add(layer.Name);
+        }
+
+        return Process(file, layers, mergeDuplicateFrames, borderPadding, spacing, innerPadding);
+    }
+
+    /// <summary>
+    /// Processes a <see cref="SpriteSheet"/> from an <see cref="AsepriteFile"/>.
+    /// </summary>
+    /// <param name="file">The <see cref="AsepriteFile"/> to process.</param>
+    /// <param name="layers">
+    /// A collection containing the name of the layers to process.  Only cels on a layer who's name matches a name in
+    /// this collection will be processed.
+    /// </param>
+    /// <returns>
+    /// <param name="mergeDuplicateFrames">Indicates whether duplicates frames should be merged.</param>
+    /// <param name="borderPadding">The amount of transparent pixels to add to the edge of the generated texture.</param>
+    /// <param name="spacing">The amount of transparent pixels to add between each texture region in the generated texture.</param>
+    /// <param name="innerPadding">The amount of transparent pixels to add around the edge of each texture region in the generated texture.</param>
+    /// <returns>
+    /// The <see cref="SpriteSheet"/> created by this method.  If <paramref name="layers"/> is empty or contains zero
+    /// elements, then <see cref="SpriteSheet.Empty"/> is returned.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="file"/> is <see langword="null"/>.</exception>
+    public static SpriteSheet Process(AsepriteFile file, ICollection<string> layers, bool mergeDuplicateFrames = true, int borderPadding = 0, int spacing = 0, int innerPadding = 0)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+
+        if (layers is null || layers.Count == 0)
+        {
+            return SpriteSheet.Empty;
+        }
+
+        TextureAtlas textureAtlas = TextureAtlasProcessor.Process(file, layers, mergeDuplicateFrames, borderPadding, spacing, innerPadding);
         AnimationTag[] tags = new AnimationTag[file.Tags.Length];
         HashSet<string> tagNameCheck = new HashSet<string>();
 

--- a/source/AsepriteDotNet/Processors/SpriteSheetProcessor.cs
+++ b/source/AsepriteDotNet/Processors/SpriteSheetProcessor.cs
@@ -92,7 +92,6 @@ public static class SpriteSheetProcessor
     /// A collection containing the name of the layers to process.  Only cels on a layer who's name matches a name in
     /// this collection will be processed.
     /// </param>
-    /// <returns>
     /// <param name="mergeDuplicateFrames">Indicates whether duplicates frames should be merged.</param>
     /// <param name="borderPadding">The amount of transparent pixels to add to the edge of the generated texture.</param>
     /// <param name="spacing">The amount of transparent pixels to add between each texture region in the generated texture.</param>

--- a/source/AsepriteDotNet/Processors/TextureAtlasProcessor.cs
+++ b/source/AsepriteDotNet/Processors/TextureAtlasProcessor.cs
@@ -77,7 +77,6 @@ public static class TextureAtlasProcessor
     /// A collection containing the name of the layers to process.  Only cels on a layer who's name matches a name in
     /// this collection will be processed.
     /// </param>
-    /// <returns>
     /// <param name="mergeDuplicateFrames">Indicates whether duplicates frames should be merged.</param>
     /// <param name="borderPadding">The amount of transparent pixels to add to the edge of the generated texture.</param>
     /// <param name="spacing">The amount of transparent pixels to add between each texture region in the generated texture.</param>

--- a/source/AsepriteDotNet/Processors/TextureAtlasProcessor.cs
+++ b/source/AsepriteDotNet/Processors/TextureAtlasProcessor.cs
@@ -23,10 +23,78 @@ public static class TextureAtlasProcessor
     /// </param>
     /// <returns>The <see cref="TextureAtlas"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="file"/> is <see langword="null"/>.</exception>
+    [Obsolete("This method will be removed in a future release.  Users should switch to one of the other appropriate Process methods", false)]
     public static TextureAtlas Process(AsepriteFile file, ProcessorOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(file);
         options ??= ProcessorOptions.Default;
+
+        return Process(file, options.OnlyVisibleLayers, options.IncludeBackgroundLayer, options.IncludeTilemapLayers, options.MergeDuplicateFrames, options.BorderPadding, options.Spacing, options.InnerPadding);
+    }
+
+    /// <summary>
+    /// Processes a <see cref="TextureAtlas"/> from an <see cref="AsepriteFile"/>.
+    /// </summary>
+    /// <param name="file">The <see cref="AsepriteFile"/> to process.</param>
+    /// <param name="onlyVisibleLayers">Indicates whether only visible layers should be processed.</param>
+    /// <param name="includeBackgroundLayer">Indicates whether the layer assigned as the background layer should be processed.</param>
+    /// <param name="includeTilemapLayers">Indicates whether tilemap layers should be processed.</param>
+    /// <param name="mergeDuplicateFrames">Indicates whether duplicates frames should be merged.</param>
+    /// <param name="borderPadding">The amount of transparent pixels to add to the edge of the generated texture.</param>
+    /// <param name="spacing">The amount of transparent pixels to add between each texture region in the generated texture.</param>
+    /// <param name="innerPadding">The amount of transparent pixels to add around the edge of each texture region in the generated texture.</param>
+    /// <returns>The <see cref="TextureAtlas"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="file"/> is <see langword="null"/>.</exception>
+    public static TextureAtlas Process(AsepriteFile file,
+                                       bool onlyVisibleLayers = true,
+                                       bool includeBackgroundLayer = false,
+                                       bool includeTilemapLayers = false,
+                                       bool mergeDuplicateFrames = true,
+                                       int borderPadding = 0,
+                                       int spacing = 0,
+                                       int innerPadding = 0)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+
+        List<string> layers = new List<string>();
+        for (int i = 0; i < file.Layers.Length; i++)
+        {
+            AsepriteLayer layer = file.Layers[i];
+            if (onlyVisibleLayers && !layer.IsVisible) { continue; }
+            if (!includeBackgroundLayer && layer.IsBackgroundLayer) { continue; }
+            if (!includeTilemapLayers && layer is AsepriteTilemapLayer) { continue; }
+            layers.Add(layer.Name);
+        }
+
+        return Process(file, layers, mergeDuplicateFrames, borderPadding, spacing, innerPadding);
+    }
+
+    /// <summary>
+    /// Processes a <see cref="TextureAtlas"/> from an <see cref="AsepriteFile"/>.
+    /// </summary>
+    /// <param name="file">The <see cref="AsepriteFile"/> to process.</param>
+    /// <param name="layers">
+    /// A collection containing the name of the layers to process.  Only cels on a layer who's name matches a name in
+    /// this collection will be processed.
+    /// </param>
+    /// <returns>
+    /// <param name="mergeDuplicateFrames">Indicates whether duplicates frames should be merged.</param>
+    /// <param name="borderPadding">The amount of transparent pixels to add to the edge of the generated texture.</param>
+    /// <param name="spacing">The amount of transparent pixels to add between each texture region in the generated texture.</param>
+    /// <param name="innerPadding">The amount of transparent pixels to add around the edge of each texture region in the generated texture.</param>
+    /// <returns>
+    /// The <see cref="TextureAtlas"/> created by this method.  If <paramref name="layers"/> is empty or contains zero
+    /// elements, then <see cref="TextureAtlas.Empty"/> is returned.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="file"/> is <see langword="null"/>.</exception>
+    public static TextureAtlas Process(AsepriteFile file, ICollection<string> layers, bool mergeDuplicateFrames = true, int borderPadding = 0, int spacing = 0, int innerPadding = 0)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+
+        if(layers is null || layers.Count == 0)
+        {
+            return TextureAtlas.Empty;
+        }
 
         int frameWidth = file.CanvasWidth;
         int frameHeight = file.CanvasHeight;
@@ -36,7 +104,7 @@ public static class TextureAtlasProcessor
 
         for (int i = 0; i < frameCount; i++)
         {
-            flattenedFrames[i] = file.Frames[i].FlattenFrame(options.OnlyVisibleLayers, options.IncludeBackgroundLayer, options.IncludeTilemapLayers);
+            flattenedFrames[i] = file.Frames[i].FlattenFrame(layers);
         }
 
         Dictionary<int, int> duplicateMap = new Dictionary<int, int>();
@@ -54,7 +122,7 @@ public static class TextureAtlasProcessor
             }
         }
 
-        if (options.MergeDuplicateFrames)
+        if (mergeDuplicateFrames)
         {
             frameCount -= duplicateMap.Count;
         }
@@ -64,14 +132,14 @@ public static class TextureAtlasProcessor
         int rows = (frameCount + columns - 1) / columns;
 
         int imageWidth = (columns * frameWidth)
-                       + (options.BorderPadding * 2)
-                       + (options.Spacing * (columns - 1))
-                       + (options.InnerPadding * 2 * columns);
+                       + (borderPadding * 2)
+                       + (spacing * (columns - 1))
+                       + (innerPadding * 2 * columns);
 
         int imageHeight = (columns * frameHeight)
-                        + (options.BorderPadding * 2)
-                        + (options.Spacing * (rows - 1))
-                        + (options.InnerPadding * 2 * rows);
+                        + (borderPadding * 2)
+                        + (spacing * (rows - 1))
+                        + (innerPadding * 2 * rows);
 
         Rgba32[] imagePixels = new Rgba32[imageWidth * imageHeight];
         TextureRegion[] regions = new TextureRegion[file.Frames.Length];
@@ -80,7 +148,7 @@ public static class TextureAtlasProcessor
 
         for (int i = 0; i < flattenedFrames.GetLength(0); i++)
         {
-            if (options.MergeDuplicateFrames && duplicateMap.TryGetValue(i, out int value))
+            if (mergeDuplicateFrames && duplicateMap.TryGetValue(i, out int value))
             {
                 TextureRegion original = originalToDuplicateLookup[value];
                 TextureRegion duplicate = new TextureRegion($"{file.Name} {i}", original.Bounds, ProcessorUtilities.GetSlicesForFrame(i, file.Slices));
@@ -94,14 +162,14 @@ public static class TextureAtlasProcessor
             Rgba32[] frame = flattenedFrames[i];
 
             int x = (column * frameWidth)
-                  + options.BorderPadding
-                  + (options.Spacing * column)
-                  + (options.InnerPadding * (column + column + 1));
+                  + borderPadding
+                  + (spacing * column)
+                  + (innerPadding * (column + column + 1));
 
             int y = (row * frameHeight)
-                  + options.BorderPadding
-                  + (options.Spacing * row)
-                  + (options.InnerPadding * (row + row + 1));
+                  + borderPadding
+                  + (spacing * row)
+                  + (innerPadding * (row + row + 1));
 
             for (int p = 0; p < frame.Length; p++)
             {

--- a/source/AsepriteDotNet/Sprite.cs
+++ b/source/AsepriteDotNet/Sprite.cs
@@ -12,6 +12,11 @@ namespace AsepriteDotNet;
 /// </summary>
 public sealed class Sprite : IEquatable<Sprite>
 {
+    /// <summary>
+    /// An empty sprite with no name, an empty texture, and an empty array of slices
+    /// </summary>
+    public static readonly Sprite Empty = new Sprite(string.Empty, Texture.Empty, Array.Empty<Slice>());
+
     private readonly Slice[] _slices;
 
     /// <summary>

--- a/source/AsepriteDotNet/SpriteSheet.cs
+++ b/source/AsepriteDotNet/SpriteSheet.cs
@@ -12,6 +12,11 @@ namespace AsepriteDotNet;
 /// </summary>
 public sealed class SpriteSheet : IEquatable<SpriteSheet>
 {
+    /// <summary>
+    /// An empty sprite sheet with no name, an empty texture atlas, and an empty collection of animation tags.
+    /// </summary>
+    public static readonly SpriteSheet Empty = new SpriteSheet(string.Empty, TextureAtlas.Empty, Array.Empty<AnimationTag>());
+
     private readonly AnimationTag[] _tags;
     /// <summary>
     /// Gets the name of this sprite sheet.

--- a/source/AsepriteDotNet/Texture.cs
+++ b/source/AsepriteDotNet/Texture.cs
@@ -13,6 +13,11 @@ namespace AsepriteDotNet;
 /// </summary>
 public sealed class Texture : IEquatable<Texture>
 {
+    /// <summary>
+    /// An empty texture, with the no name, 0 width, 0, height, and an empty array of pixels
+    /// </summary>
+    public static readonly Texture Empty = new Texture(string.Empty, Size.Empty, Array.Empty<Rgba32>());
+
     private readonly Rgba32[] _pixels;
 
     /// <summary>

--- a/source/AsepriteDotNet/TextureAtlas.cs
+++ b/source/AsepriteDotNet/TextureAtlas.cs
@@ -12,6 +12,11 @@ namespace AsepriteDotNet;
 /// </summary>
 public sealed class TextureAtlas : IEquatable<TextureAtlas>
 {
+    /// <summary>
+    /// An empty texture atlas with no name, an empty texture, and an empty collection of regions.
+    /// </summary>
+    public static readonly TextureAtlas Empty = new TextureAtlas(string.Empty, Texture.Empty, Array.Empty<TextureRegion>());
+
     private readonly TextureRegion[] _regions;
 
     /// <summary>

--- a/source/AsepriteDotNet/Tilemap.cs
+++ b/source/AsepriteDotNet/Tilemap.cs
@@ -12,6 +12,11 @@ namespace AsepriteDotNet;
 /// </summary>
 public sealed class Tilemap : IEquatable<Tilemap>
 {
+    /// <summary>
+    /// An empty tilemap with no name, an empty collection of tilesets, and an empty collection of tilemap layers.
+    /// </summary>
+    public static readonly Tilemap Empty = new Tilemap(string.Empty, Array.Empty<Tileset>(), Array.Empty<TilemapLayer>());
+
     private readonly Tileset[] _tilesets;
     private readonly TilemapLayer[] _layers;
 

--- a/tests/AsepriteDotNet.Tests/Aseprite/AsepriteColorUtilityTests.cs
+++ b/tests/AsepriteDotNet.Tests/Aseprite/AsepriteColorUtilityTests.cs
@@ -17,9 +17,6 @@ namespace AsepriteDotNet.Tests.Aseprite
         private static readonly Rgba32 _green = new Rgba32(106, 190, 48, 255);
         private static readonly Rgba32 _orange = new Rgba32(223, 113, 38, 255);
         private static readonly Rgba32 _transparent = new Rgba32(0, 0, 0, 0);
-        private static readonly Rgba32 _purple = new Rgba32(63, 63, 116, 255);
-        private static readonly Rgba32 _pink = new Rgba32(215, 123, 186, 255);
-        private static readonly Rgba32 _red = new Rgba32(172, 50, 50, 255);
 
         [Theory]
         [InlineData(AsepriteBlendMode.Normal)]

--- a/tests/AsepriteDotNet.Tests/Compression/ZlibTests.cs
+++ b/tests/AsepriteDotNet.Tests/Compression/ZlibTests.cs
@@ -23,14 +23,16 @@ public class ZlibTests
         Assert.Equal(expected, decompressed);
     }
 
-    private byte[] GetRandomBytes(int size)
+    private static byte[] GetRandomBytes(int size)
     {
         byte[] data = new byte[size];
+        #pragma warning disable CA5394
         Random.Shared.NextBytes(data);
+        #pragma warning restore CA5394
         return data;
     }
 
-    private byte[] CompressBytes(byte[] data)
+    private static byte[] CompressBytes(byte[] data)
     {
         using MemoryStream ms = new();
         using ZLibStream zOut = new(ms, CompressionMode.Compress);

--- a/tests/AsepriteDotNet.Tests/IO/AsepriteFileLoaderTests.cs
+++ b/tests/AsepriteDotNet.Tests/IO/AsepriteFileLoaderTests.cs
@@ -269,8 +269,8 @@ namespace AsepriteDotNet.Tests.IO
 
             Assert.Equal(0, tileset.ID);
             Assert.Equal(11, tileset.TileCount);
-            Assert.Equal(8, tileset.Size.Width);
-            Assert.Equal(8, tileset.Size.Height);
+            Assert.Equal(8, tileset.TileSize.Width);
+            Assert.Equal(8, tileset.TileSize.Height);
 
             Rgba32[] expectedTilesetPixels = new Rgba32[]
             {

--- a/tests/AsepriteDotNet.Tests/IO/AsepriteFileLoaderTests.cs
+++ b/tests/AsepriteDotNet.Tests/IO/AsepriteFileLoaderTests.cs
@@ -12,7 +12,7 @@ namespace AsepriteDotNet.Tests.IO
 {
     public class AsepriteFileLoaderTests
     {
-        private string GetPath(string name)
+        private static string GetPath(string name)
         {
             return Path.Combine(Environment.CurrentDirectory, "Files", name);
         }

--- a/tests/AsepriteDotNet.Tests/Processors/AnimatedTilemapProcessorTest.cs
+++ b/tests/AsepriteDotNet.Tests/Processors/AnimatedTilemapProcessorTest.cs
@@ -17,8 +17,8 @@ public sealed class AnimatedTilemapProcessorTestFixture
     public Rgba32 Green { get; } = new Rgba32(0, 255, 0, 255);
     public Rgba32 Blue { get; } = new Rgba32(0, 0, 255, 255);
     public Rgba32 White { get; } = new Rgba32(255, 255, 255, 255);
-    public Rgba32 Gray{ get; } = new Rgba32(128, 128, 128, 255);
-    public Rgba32 Black{ get; } = new Rgba32(0, 0, 0, 255);
+    public Rgba32 Gray { get; } = new Rgba32(128, 128, 128, 255);
+    public Rgba32 Black { get; } = new Rgba32(0, 0, 0, 255);
     public Rgba32 Transparent { get; } = new Rgba32(0, 0, 0, 0);
 
 
@@ -122,7 +122,7 @@ public sealed class AnimatedTilemapProcessorTests : IClassFixture<AnimatedTilema
     [Fact]
     public void Process_OnlyVisibleLayers_True_Processes_Only_Visible_Layers()
     {
-        AnimatedTilemap tilemap = AnimatedTilemapProcessor.Process(_fixture.AsepriteFile, ProcessorOptions.Default);
+        AnimatedTilemap tilemap = AnimatedTilemapProcessor.Process(_fixture.AsepriteFile, true);
 
         //  Expect the name of the aseprite file to be the name of the tilemap.
         Assert.Equal(_fixture.AsepriteFile.Name, tilemap.Name);
@@ -161,8 +161,7 @@ public sealed class AnimatedTilemapProcessorTests : IClassFixture<AnimatedTilema
     [Fact]
     public void Process_OnlyVisibleLayers_False_Processes_All_Layers()
     {
-        ProcessorOptions options = ProcessorOptions.Default with { OnlyVisibleLayers = false };
-        AnimatedTilemap tilemap = AnimatedTilemapProcessor.Process(_fixture.AsepriteFile, options);
+        AnimatedTilemap tilemap = AnimatedTilemapProcessor.Process(_fixture.AsepriteFile, false);
 
         //  Expect the name of the aseprite file to be the name of the tilemap.
         Assert.Equal(_fixture.AsepriteFile.Name, tilemap.Name);
@@ -254,7 +253,7 @@ public sealed class AnimatedTilemapProcessorTests : IClassFixture<AnimatedTilema
                                                 _fixture.AsepriteFile.UserData,
                                                 new List<string>());
 
-        Assert.Throws<InvalidOperationException>(() => AnimatedTilemapProcessor.Process(aseFile));
+        Assert.Throws<InvalidOperationException>(() => AnimatedTilemapProcessor.Process(aseFile, true));
     }
 
     private static void AssertLayer(TilemapLayer tilemapLayer, AsepriteTilemapLayer aseLayer, AsepriteTilemapCel aseCel)

--- a/tests/AsepriteDotNet.Tests/Processors/SpriteProcessorTests.cs
+++ b/tests/AsepriteDotNet.Tests/Processors/SpriteProcessorTests.cs
@@ -23,7 +23,7 @@ public sealed class SpriteProcessorTestsFixture
         palette.Resize(2);
         palette[0] = Black;
         palette[1] = White;
-        
+
 
         AsepriteTileset[] tilesets = Array.Empty<AsepriteTileset>();
 
@@ -61,7 +61,7 @@ public sealed class SpriteProcessorTestsFixture
         AsepriteFile = new AsepriteFile(Name,
                                         palette,
                                         2,
-                                        3,
+                                        2,
                                         AsepriteColorDepth.RGBA,
                                         new List<AsepriteFrame>(frames),
                                         new List<AsepriteLayer>(layers),
@@ -85,7 +85,7 @@ public sealed class SpriteProcessorTests : IClassFixture<SpriteProcessorTestsFix
     [InlineData(1)]
     public void Process_Sprite_And_Texture_Name_Include_Correct_Index(int frame)
     {
-        Sprite sprite = SpriteProcessor.Process(_fixture.AsepriteFile, frame);
+        Sprite sprite = SpriteProcessor.Process(_fixture.AsepriteFile, frame, true, false, false);
 
         string name = $"{_fixture.Name} {frame}";
 
@@ -98,14 +98,14 @@ public sealed class SpriteProcessorTests : IClassFixture<SpriteProcessorTestsFix
     [InlineData(2)]
     public void Process_Throws_Exception_When_Frame_Index_Out_Of_Range(int frame)
     {
-        Assert.Throws<IndexOutOfRangeException>(() => SpriteProcessor.Process(_fixture.AsepriteFile, frame));
+        Assert.Throws<IndexOutOfRangeException>(() => SpriteProcessor.Process(_fixture.AsepriteFile, frame, true, false, false));
     }
 
     [Fact]
     public void Process_Processes_Given_Frame()
     {
-        Sprite frame0Sprite = SpriteProcessor.Process(_fixture.AsepriteFile, 0);
-        Sprite frame1Sprite = SpriteProcessor.Process(_fixture.AsepriteFile, 1);
+        Sprite frame0Sprite = SpriteProcessor.Process(_fixture.AsepriteFile, 0, true, false, false);
+        Sprite frame1Sprite = SpriteProcessor.Process(_fixture.AsepriteFile, 1, true, false, false);
 
         Rgba32[] frame0Expected = new Rgba32[] { _fixture.Black, _fixture.Black, _fixture.Black, _fixture.Black };
         Rgba32[] frame1Expected = new Rgba32[] { _fixture.White, _fixture.White, _fixture.White, _fixture.White };
@@ -115,5 +115,28 @@ public sealed class SpriteProcessorTests : IClassFixture<SpriteProcessorTestsFix
 
         Assert.Equal(frame0Expected, frame0Actual);
         Assert.Equal(frame1Expected, frame1Actual);
+    }
+
+    [Fact]
+    public void Process_Returns_Expected_When_Given_Existing_Layer_Name()
+    {
+        string name = _fixture.AsepriteFile.Name + " 0";
+        Size size = new Size(_fixture.AsepriteFile.CanvasWidth, _fixture.AsepriteFile.CanvasHeight);
+        Rgba32[] pixels = new Rgba32[] { _fixture.Black, _fixture.Black, _fixture.Black, _fixture.Black };
+        Texture texture = new Texture(name, size, pixels);
+        Slice[] slices = Array.Empty<Slice>();
+
+        Sprite expected = new Sprite(name, texture, slices);
+        Sprite actual = SpriteProcessor.Process(_fixture.AsepriteFile, 0, new List<string>() {_fixture.AsepriteFile.Layers[0].Name});
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void Process_Returns_Empty_Sprite_When_No_Layers()
+    {
+        Sprite expected = Sprite.Empty;
+        Sprite actual = SpriteProcessor.Process(_fixture.AsepriteFile, 0, Array.Empty<string>());
+        Assert.Equal(expected, actual);
     }
 }

--- a/tests/AsepriteDotNet.Tests/Processors/SpriteSheetProcessorTests.cs
+++ b/tests/AsepriteDotNet.Tests/Processors/SpriteSheetProcessorTests.cs
@@ -100,9 +100,8 @@ public sealed class SpriteSheetProcessorTests : IClassFixture<SpriteSheetProcess
     [InlineData(false, false, false, false, 0, 0, 0)]
     public void Process_Parameters_To_TextureAtlasProcess_Correctly(bool onlyVisible, bool includeBackground, bool includeTilemap, bool mergeDuplicates, int borderPadding, int spacing, int innerPadding)
     {
-        ProcessorOptions options = new ProcessorOptions(onlyVisible, includeBackground, includeTilemap, mergeDuplicates, borderPadding, spacing, innerPadding);
-        SpriteSheet sheet = SpriteSheetProcessor.Process(_fixture.AsepriteFile, options);
-        TextureAtlas expected = TextureAtlasProcessor.Process(_fixture.AsepriteFile, options);
+        SpriteSheet sheet = SpriteSheetProcessor.Process(_fixture.AsepriteFile, onlyVisible, includeBackground, includeTilemap, mergeDuplicates, borderPadding, spacing, innerPadding);
+        TextureAtlas expected = TextureAtlasProcessor.Process(_fixture.AsepriteFile, onlyVisible, includeBackground, includeTilemap, mergeDuplicates, borderPadding, spacing, innerPadding);
 
         Assert.Equal(expected, sheet.TextureAtlas);
     }
@@ -110,7 +109,7 @@ public sealed class SpriteSheetProcessorTests : IClassFixture<SpriteSheetProcess
     [Fact]
     public void Process_SpriteSheet_Atlas_and_Texture_Names_Same_As_File_Name()
     {
-        SpriteSheet sheet = SpriteSheetProcessor.Process(_fixture.AsepriteFile);
+        SpriteSheet sheet = SpriteSheetProcessor.Process(_fixture.AsepriteFile, true, false, false, true, 0, 0, 0);
         Assert.Equal(_fixture.Name, sheet.Name);
         Assert.Equal(_fixture.Name, sheet.TextureAtlas.Name);
         Assert.Equal(_fixture.Name, sheet.TextureAtlas.Texture.Name);
@@ -119,7 +118,7 @@ public sealed class SpriteSheetProcessorTests : IClassFixture<SpriteSheetProcess
     [Fact]
     public void Processes_All_Tags()
     {
-        SpriteSheet sheet = SpriteSheetProcessor.Process(_fixture.AsepriteFile);
+        SpriteSheet sheet = SpriteSheetProcessor.Process(_fixture.AsepriteFile, true, false, false, true, 0, 0, 0);
         Assert.Equal(_fixture.AsepriteFile.Tags.Length, sheet.Tags.Length);
     }
 
@@ -147,6 +146,14 @@ public sealed class SpriteSheetProcessorTests : IClassFixture<SpriteSheetProcess
                                    _fixture.AsepriteFile.UserData,
                                    new List<string>());
 
-        Assert.Throws<InvalidOperationException>(() => SpriteSheetProcessor.Process(aseFile));
+        Assert.Throws<InvalidOperationException>(() => SpriteSheetProcessor.Process(aseFile, true, false, false, true, 0, 0, 0));
+    }
+
+    [Fact]
+    public void Process_Returns_Empty_SpriteSheet_When_No_Layers()
+    {
+        SpriteSheet expected = SpriteSheet.Empty;
+        SpriteSheet actual = SpriteSheetProcessor.Process(_fixture.AsepriteFile, Array.Empty<string>());
+        Assert.Equal(expected, actual);
     }
 }

--- a/tests/AsepriteDotNet.Tests/Processors/TextureAtlasProcessorTests.cs
+++ b/tests/AsepriteDotNet.Tests/Processors/TextureAtlasProcessorTests.cs
@@ -89,7 +89,7 @@ public sealed class TextureAtlasProcessorTests : IClassFixture<TextureAtlasProce
     [Fact]
     public void Process_Atlas_And_Texture_Name_Same_As_File_Name()
     {
-        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile);
+        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile, true, false, false, true, 0, 0, 0);
         Assert.Equal(_fixture.Name, atlas.Name);
         Assert.Equal(_fixture.Name, atlas.Texture.Name);
     }
@@ -97,14 +97,14 @@ public sealed class TextureAtlasProcessorTests : IClassFixture<TextureAtlasProce
     [Fact]
     public void Process_One_Region_Per_Frame()
     {
-        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile);
+        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile, true, false, false, true, 0, 0, 0);
         Assert.Equal(_fixture.AsepriteFile.Frames.Length, atlas.Regions.Length);
     }
 
     [Fact]
     public void ProcessRegion_Names_Are_Frame_Names()
     {
-        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile);
+        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile, true, false, false, true, 0, 0, 0);
 
         Assert.Equal(_fixture.AsepriteFile.Frames[0].Name, atlas.Regions[0].Name);
         Assert.Equal(_fixture.AsepriteFile.Frames[1].Name, atlas.Regions[1].Name);
@@ -115,8 +115,7 @@ public sealed class TextureAtlasProcessorTests : IClassFixture<TextureAtlasProce
     [Fact]
     public void Process_Duplicate_Frame_Is_Merged()
     {
-        ProcessorOptions options = ProcessorOptions.Default with { MergeDuplicateFrames = true };
-        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile, options);
+        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile, true, false, false, true, 0, 0, 0);
 
         Rgba32[] expected = new Rgba32[]
         {
@@ -138,8 +137,7 @@ public sealed class TextureAtlasProcessorTests : IClassFixture<TextureAtlasProce
     [Fact]
     public void Process_Duplicate_Frame_Not_Merged()
     {
-        ProcessorOptions options = ProcessorOptions.Default with { MergeDuplicateFrames = false };
-        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile, options);
+        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile, true, false, false, false, 0, 0, 0);
 
         Rgba32[] expected = new Rgba32[]
         {
@@ -161,8 +159,7 @@ public sealed class TextureAtlasProcessorTests : IClassFixture<TextureAtlasProce
     [Fact]
     public void Process_Border_Padding_Added_Correctly()
     {
-        ProcessorOptions options = ProcessorOptions.Default with { BorderPadding = 1 };
-        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile, options);
+        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile, true, false, false, true, 1, 0, 0);
 
         Rgba32[] expected = new Rgba32[]
         {
@@ -186,8 +183,7 @@ public sealed class TextureAtlasProcessorTests : IClassFixture<TextureAtlasProce
     [Fact]
     public void Process_Spacing_Added_Correctly()
     {
-        ProcessorOptions options = ProcessorOptions.Default with { Spacing = 1 };
-        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile, options);
+        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile, true, false, false, true, 0, 1, 0);
 
         Rgba32[] expected = new Rgba32[]
         {
@@ -210,8 +206,7 @@ public sealed class TextureAtlasProcessorTests : IClassFixture<TextureAtlasProce
     [Fact]
     public void Process_InnerPadding_Added_Correctly()
     {
-        ProcessorOptions options = ProcessorOptions.Default with { InnerPadding = 1 };
-        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile, options);
+        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile, true, false, false, true, 0, 0, 1);
 
         Rgba32[] expected = new Rgba32[]
         {
@@ -237,8 +232,7 @@ public sealed class TextureAtlasProcessorTests : IClassFixture<TextureAtlasProce
     [Fact]
     public void Process_Combined_Border_Padding_Spacing_Inner_Padding_Added_Correctly()
     {
-        ProcessorOptions options = ProcessorOptions.Default with { BorderPadding = 1, Spacing = 1, InnerPadding = 1 };
-        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile, options);
+        TextureAtlas atlas = TextureAtlasProcessor.Process(_fixture.AsepriteFile, true, false, false, true, 1, 1, 1);
 
         Rgba32[] expected = new Rgba32[]
         {
@@ -262,5 +256,13 @@ public sealed class TextureAtlasProcessorTests : IClassFixture<TextureAtlasProce
         Assert.Equal(new Rectangle(7, 2, 2, 2), atlas.Regions[1].Bounds);
         Assert.Equal(new Rectangle(2, 7, 2, 2), atlas.Regions[2].Bounds);
         Assert.Equal(new Rectangle(2, 2, 2, 2), atlas.Regions[3].Bounds);
+    }
+
+    [Fact]
+    public void Process_Returns_Empty_TextureAtlas_When_No_Layers()
+    {
+        TextureAtlas expected = TextureAtlas.Empty;
+        TextureAtlas actual = TextureAtlasProcessor.Process(_fixture.AsepriteFile, Array.Empty<string>());
+        Assert.Equal(expected, actual);
     }
 }

--- a/tests/AsepriteDotNet.Tests/Processors/TilemapProcessorTests.cs
+++ b/tests/AsepriteDotNet.Tests/Processors/TilemapProcessorTests.cs
@@ -174,7 +174,7 @@ public sealed class TilemapProcessorTests : IClassFixture<TilemapProcessorTestFi
         Assert.Throws<InvalidOperationException>(() => TilemapProcessor.Process(aseFile, 0, true));
     }
 
-    private void AssertLayer(TilemapLayer layer, string name, int tilesetID, int columns, int rows, Point offset, ReadOnlySpan<AsepriteTile> tiles)
+    private static void AssertLayer(TilemapLayer layer, string name, int tilesetID, int columns, int rows, Point offset, ReadOnlySpan<AsepriteTile> tiles)
     {
         Assert.Equal(name, layer.Name);
         Assert.Equal(tilesetID, layer.TilesetID);

--- a/tests/AsepriteDotNet.Tests/Processors/TilemapProcessorTests.cs
+++ b/tests/AsepriteDotNet.Tests/Processors/TilemapProcessorTests.cs
@@ -77,8 +77,7 @@ public sealed class TilemapProcessorTests : IClassFixture<TilemapProcessorTestFi
     [Fact]
     public void Process_OnlyVisibleLayers_True_Processes_Only_Visible_Layers()
     {
-        ProcessorOptions options = ProcessorOptions.Default with { OnlyVisibleLayers = true };
-        Tilemap tilemap = TilemapProcessor.Process(_fixture.AsepriteFile, 0, options);
+        Tilemap tilemap = TilemapProcessor.Process(_fixture.AsepriteFile, 0, true);
 
         Assert.Equal(_fixture.AsepriteFile.Name, tilemap.Name);
 
@@ -95,8 +94,7 @@ public sealed class TilemapProcessorTests : IClassFixture<TilemapProcessorTestFi
     [Fact]
     public void Process_OnlyVisibleLayers_False_Processes_All_Layers()
     {
-        ProcessorOptions options = ProcessorOptions.Default with { OnlyVisibleLayers = false };
-        Tilemap tilemap = TilemapProcessor.Process(_fixture.AsepriteFile, 0, options);
+        Tilemap tilemap = TilemapProcessor.Process(_fixture.AsepriteFile, 0, false);
 
         Assert.Equal(_fixture.AsepriteFile.Name, tilemap.Name);
 
@@ -120,9 +118,9 @@ public sealed class TilemapProcessorTests : IClassFixture<TilemapProcessorTestFi
     [Fact]
     public void Process_Index_Out_Of_Range_Throws_Exception()
     {
-        Assert.Throws<IndexOutOfRangeException>(() => TilemapProcessor.Process(_fixture.AsepriteFile, -1));
-        Assert.Throws<IndexOutOfRangeException>(() => TilemapProcessor.Process(_fixture.AsepriteFile, _fixture.AsepriteFile.Frames.Length));
-        Assert.Throws<IndexOutOfRangeException>(() => TilemapProcessor.Process(_fixture.AsepriteFile, _fixture.AsepriteFile.Frames.Length + 1));
+        Assert.Throws<IndexOutOfRangeException>(() => TilemapProcessor.Process(_fixture.AsepriteFile, -1, true));
+        Assert.Throws<IndexOutOfRangeException>(() => TilemapProcessor.Process(_fixture.AsepriteFile, _fixture.AsepriteFile.Frames.Length, true));
+        Assert.Throws<IndexOutOfRangeException>(() => TilemapProcessor.Process(_fixture.AsepriteFile, _fixture.AsepriteFile.Frames.Length + 1, true));
     }
 
     [Fact]
@@ -173,7 +171,7 @@ public sealed class TilemapProcessorTests : IClassFixture<TilemapProcessorTestFi
                                                 _fixture.AsepriteFile.UserData,
                                                 []);
 
-        Assert.Throws<InvalidOperationException>(() => TilemapProcessor.Process(aseFile, 0));
+        Assert.Throws<InvalidOperationException>(() => TilemapProcessor.Process(aseFile, 0, true));
     }
 
     private void AssertLayer(TilemapLayer layer, string name, int tilesetID, int columns, int rows, Point offset, ReadOnlySpan<AsepriteTile> tiles)
@@ -191,5 +189,13 @@ public sealed class TilemapProcessorTests : IClassFixture<TilemapProcessorTestFi
             Assert.Equal(tiles[i].FlipVertically, layer.Tiles[i].FlipVertically);
             Assert.Equal(tiles[i].FlipDiagonally, layer.Tiles[i].FlipDiagonally);
         }
+    }
+
+    [Fact]
+    public void Process_Returns_Empty_TilemapLayer_When_No_Layers()
+    {
+        Tilemap expected = Tilemap.Empty;
+        Tilemap actual = TilemapProcessor.Process(_fixture.AsepriteFile, 0, Array.Empty<string>());
+        Assert.Equal(expected, actual);
     }
 }

--- a/tests/AsepriteDotNet.Tests/Processors/TilesetProcessorTests.cs
+++ b/tests/AsepriteDotNet.Tests/Processors/TilesetProcessorTests.cs
@@ -50,11 +50,11 @@ public sealed class TilesetProcessorTests : IClassFixture<TilesetProcessorTestFi
 
         Assert.Equal(aseTileset.ID, tileset.ID);
         Assert.Equal(aseTileset.Name, tileset.Name);
-        Assert.Equal(aseTileset.Size.Width, tileset.TileSize.Width);
-        Assert.Equal(aseTileset.Size.Height, tileset.TileSize.Height);
+        Assert.Equal(aseTileset.TileSize.Width, tileset.TileSize.Width);
+        Assert.Equal(aseTileset.TileSize.Height, tileset.TileSize.Height);
         Assert.Equal(aseTileset.Name, tileset.Texture.Name);
-        Assert.Equal(aseTileset.Size.Width, tileset.Texture.Size.Width);
-        Assert.Equal(aseTileset.Size.Height * aseTileset.TileCount, tileset.Texture.Size.Height);
+        Assert.Equal(aseTileset.TileSize.Width, tileset.Texture.Size.Width);
+        Assert.Equal(aseTileset.TileSize.Height * aseTileset.TileCount, tileset.Texture.Size.Height);
         Assert.Equal(aseTileset.Pixels.ToArray(), tileset.Texture.Pixels.ToArray());
     }
 
@@ -67,11 +67,11 @@ public sealed class TilesetProcessorTests : IClassFixture<TilesetProcessorTestFi
 
         Assert.Equal(aseTileset.ID, tileset.ID);
         Assert.Equal(aseTileset.Name, tileset.Name);
-        Assert.Equal(aseTileset.Size.Width, tileset.TileSize.Width);
-        Assert.Equal(aseTileset.Size.Height, tileset.TileSize.Height);
+        Assert.Equal(aseTileset.TileSize.Width, tileset.TileSize.Width);
+        Assert.Equal(aseTileset.TileSize.Height, tileset.TileSize.Height);
         Assert.Equal(aseTileset.Name, tileset.Texture.Name);
-        Assert.Equal(aseTileset.Size.Width, tileset.Texture.Size.Width);
-        Assert.Equal(aseTileset.Size.Height * aseTileset.TileCount, tileset.Texture.Size.Height);
+        Assert.Equal(aseTileset.TileSize.Width, tileset.Texture.Size.Width);
+        Assert.Equal(aseTileset.TileSize.Height * aseTileset.TileCount, tileset.Texture.Size.Height);
         Assert.Equal(aseTileset.Pixels.ToArray(), tileset.Texture.Pixels.ToArray());
     }
 


### PR DESCRIPTION
## Prerequisites
- [x] I have verified that there are no existing pull requests that would overlap with this pull request.
- [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
- [x] I Have verified that this pull request adheres to this project's code of conduct.
- [x] I have written a descriptive title for this pull request.
- [x] I have provided appropriate test coverage were applicable.

## Description
Added new `AsepriteFrameExtensions.FlattenFrame(this AsepriteFrame frame, ICollection<string> layers)` overload which allows users to specify the name of layers explicitly to process..

All processors were updated to make user of this new feature.

`ProcessorOptions` has been deprecated in favor of using new Process methods.
