### PR TITLE
Fix Normal() not factoring in opacity

### DIFF
--- a/source/AsepriteDotNet/Aseprite/AsepriteColorUtilities.cs
+++ b/source/AsepriteDotNet/Aseprite/AsepriteColorUtilities.cs
@@ -245,7 +245,7 @@ internal static class AsepriteColorUtilities
 
         opacity = Calc.MultiplyUnsigned8Bit(source.A, opacity);
 
-        int a = source.A + backdrop.A - Calc.MultiplyUnsigned8Bit(backdrop.A, source.A);
+        int a = backdrop.A + opacity - Calc.MultiplyUnsigned8Bit(backdrop.A, opacity);
         int r = backdrop.R + (source.R - backdrop.R) * opacity / a;
         int g = backdrop.G + (source.G - backdrop.G) * opacity / a;
         int b = backdrop.B + (source.B - backdrop.B) * opacity / a;


### PR DESCRIPTION
## Prerequisites
- [x] I have verified that there are no existing pull requests that would overlap with this pull request.
- [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
- [x] I Have verified that this pull request adheres to this project's code of conduct.
- [X] I have written a descriptive title for this pull request.
- [X] I have provided appropriate test coverage were applicable.

## Description
The alpha calculation in Normal() did not factor in opacity, causing layer and cel opacity to render incorrectly against transparent layers.

## Related Issue Ticket Numbers
N/A
